### PR TITLE
chore: constrain langchain dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,10 +22,10 @@ Mako==1.3.5
 MarkupSafe==2.1.5
 monotonic==1.6
 posthog==3.5.0
-openai>=1.40.0
-langchain>=0.2.12
-langchain-openai>=0.1.22
-langchain-community>=0.2.12
+openai==1.40.0
+langchain==0.2.13
+langchain-openai==0.1.22
+langchain-community==0.2.12
 PyMySQL==1.1.1
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1


### PR DESCRIPTION
just setting as constant the dependency versions for langchain* and openai, 
it was taking forever for the codespace to setup, then i constrained them to compatible versions and all good.

## Before
I didn't record everything, it never got setup

https://github.com/user-attachments/assets/4d748cf8-0fb1-4f9d-8b77-f2a8e3e687fa

