### PR TITLE
Enrich Hogflix seed data: realistic browser context, growth shape, and full PostHog product surface

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           enable-cache: true
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ run: check-env db seed artifacts
 	uv run python app.py
 
 seed:
-	uv run python scripts/seed_demo_data.py -d $${DAYS:-30} -i $${ITER:-100}
+	uv run python scripts/seed_demo_data.py -d $${DAYS:-120} -i $${ITER:-300}
 
 artifacts:
 	uv run python scripts/create_posthog_artifacts.py

--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 This repository allows you to spin up a demo app which has been instrumented with PostHog, and seed PostHog historic data and artifacts to provide a full-featured demo environment showcasing all features.
 
+## Required: Personal API key
+
+This repo creates real PostHog artifacts (cohorts, actions, dashboards, surveys, flags, experiments, insights) via the API. You need a Personal API key with these 8 scopes:
+
+- action:write
+- cohort:write
+- dashboard:write
+- experiment:write
+- feature_flag:write
+- insight:write
+- query:read
+- survey:write
+
+Create one at https://us.posthog.com/settings/user-api-keys (Settings → Personal API keys → Create), tick the 7 Write checkboxes plus Read on Query, copy the key, and add it to your .env as PH_PERSONAL_API_KEY=phs_...
+
+If you skip this step, `make artifacts` will fail with a clear message naming the missing scopes.
+
 ## Prerequisites
 
 If you choose to run the demo entirely in your browser using GitHub Code Spaces, skip the requirements and go straight to Option 3, otherwise follow the prerequisites instructions. 

--- a/scripts/create_posthog_artifacts.py
+++ b/scripts/create_posthog_artifacts.py
@@ -2,6 +2,7 @@ import requests
 import sys
 from argparse import ArgumentParser
 import os
+from datetime import datetime, timedelta, timezone
 from dotenv import load_dotenv
 from pathlib import Path
 from urllib.parse import quote
@@ -689,3 +690,832 @@ except PostHogForbiddenError as e:
     report_403_and_reraise(e, "creating feature flag")
 
 
+# =============================================================================
+# Phase 8: extended artifacts (surveys, more flags, experiment, cohorts,
+# insights, dashboards). Each helper is idempotent: it checks for an existing
+# artifact with the same name (or key, for flags) before creating.
+# Errors are caught locally so a single failure does not abort the whole run.
+# =============================================================================
+
+
+def _list_all(endpoint, params=None):
+    """Return all items at a list endpoint (best-effort, single page).
+
+    Used as a more reliable idempotency helper for endpoints where the
+    `?search=` parameter is unsupported or unreliable (surveys, experiments,
+    dashboards). Reads up to 100 items, which is plenty for a demo project.
+    """
+    try:
+        query = params or {"limit": 100}
+        resp = requests.get(url + endpoint, headers=headers, params=query, timeout=30)
+        if resp.status_code != 200:
+            return []
+        data = resp.json()
+        if isinstance(data, list):
+            return data
+        return data.get("results", [])
+    except Exception:
+        return []
+
+
+def _find_by_name(endpoint, name):
+    """Idempotency helper: find an artifact by exact name match.
+
+    Tries the existing search-based helper first, then falls back to listing
+    all items. Returns the matching item dict or None.
+    """
+    hit = get_existing_by(endpoint, 'name', name)
+    if hit:
+        return hit
+    for item in _list_all(endpoint):
+        if isinstance(item, dict) and item.get('name') == name:
+            return item
+    return None
+
+
+def _find_flag_by_key(key):
+    """Idempotency helper for feature flags (matched by `key`, not `name`)."""
+    hit = get_existing_by(feature_flag_endpoint, 'key', key)
+    if hit:
+        return hit
+    for item in _list_all(feature_flag_endpoint):
+        if isinstance(item, dict) and item.get('key') == key:
+            return item
+    return None
+
+
+def create_surveys():
+    """Create demo surveys.
+
+    1. 'Post-purchase NPS' — popover rating survey, no end_date (running
+       indefinitely on purpose; this surfaces issue E7 — surveys that have
+       outlived their usefulness because nobody set an end date).
+    2. 'Why did you cancel?' — open-text question, end_date 30 days from now.
+    """
+    surveys_endpoint = '/surveys/'
+    surveys = [
+        {
+            "name": "Post-purchase NPS",
+            "description": "How likely are you to recommend Hogflix?",
+            "type": "popover",
+            "questions": [
+                {
+                    "type": "rating",
+                    "scale": 10,
+                    "display": "number",
+                    "question": "How likely are you to recommend Hogflix to a friend?",
+                    "lowerBoundLabel": "Not likely",
+                    "upperBoundLabel": "Very likely",
+                }
+            ],
+            "conditions": {
+                "events": {
+                    "values": [{"name": "subscription_purchased"}]
+                }
+            },
+            # No end_date intentionally — issue E7.
+            "start_date": datetime.now(timezone.utc).isoformat(),
+        },
+        {
+            "name": "Why did you cancel?",
+            "description": "Cancellation feedback",
+            "type": "popover",
+            "questions": [
+                {
+                    "type": "open",
+                    "question": "We're sorry to see you go. What made you cancel?",
+                }
+            ],
+            "conditions": {
+                "events": {
+                    "values": [{"name": "subscription_cancelled"}]
+                }
+            },
+            "start_date": datetime.now(timezone.utc).isoformat(),
+            "end_date": (datetime.now(timezone.utc) + timedelta(days=30)).isoformat(),
+        },
+    ]
+    for survey in surveys:
+        try:
+            existing = _find_by_name(surveys_endpoint, survey['name'])
+            if existing:
+                print(f"  [skip] survey already exists: {survey['name']}")
+                continue
+            resp = make_posthog_api_request(surveys_endpoint, survey)
+            if resp and 'id' in resp:
+                print(f"  [ok] created survey: {survey['name']}")
+            else:
+                print(f"  [warn] survey create returned no id: {survey['name']}")
+        except PostHogForbiddenError as e:
+            print(f"  [error] 403 creating survey '{survey['name']}': {e.body[:200]}")
+            print("  Hint: scope 'survey:write' may be missing.")
+        except Exception as e:
+            print(f"  [error] failed creating survey '{survey['name']}': {e}")
+
+
+def create_more_feature_flags():
+    """Create additional feature flags. Several are intentionally messy.
+
+    - action_mode_on: 50% rollout (real flag, may already exist from
+      earlier creation — skipped if so).
+    - payment_flow_v2: 100% rollout, stale (issue E3).
+    - premium_trial_banner: 0% rollout, never enabled (issue E4).
+    - churn_risk_targeting: property targeting on plan='Free' for 60+ days.
+    """
+    flags = [
+        {
+            "name": "Action mode on",
+            "key": "action_mode_on",
+            "tags": ["demo"],
+            "filters": {
+                "groups": [
+                    {"properties": [], "rollout_percentage": 50}
+                ],
+                "payloads": {},
+                "multivariate": None,
+            },
+        },
+        {
+            "name": "Payment flow v2 (stale)",
+            "key": "payment_flow_v2",
+            "tags": ["demo", "stale"],
+            "filters": {
+                "groups": [
+                    {"properties": [], "rollout_percentage": 100}
+                ],
+                "payloads": {},
+                "multivariate": None,
+            },
+        },
+        {
+            "name": "Premium trial banner (never enabled)",
+            "key": "premium_trial_banner",
+            "tags": ["demo", "unused"],
+            "filters": {
+                "groups": [
+                    {"properties": [], "rollout_percentage": 0}
+                ],
+                "payloads": {},
+                "multivariate": None,
+            },
+        },
+        {
+            "name": "Churn risk targeting",
+            "key": "churn_risk_targeting",
+            "tags": ["demo"],
+            "filters": {
+                "groups": [
+                    {
+                        "properties": [
+                            {
+                                "key": "plan",
+                                "type": "person",
+                                "value": ["Free"],
+                                "operator": "exact",
+                            },
+                            {
+                                "key": "signup_date",
+                                "type": "person",
+                                "value": "-60d",
+                                "operator": "is_date_before",
+                            },
+                        ],
+                        "rollout_percentage": 100,
+                    }
+                ],
+                "payloads": {},
+                "multivariate": None,
+            },
+        },
+    ]
+    for flag in flags:
+        try:
+            existing = _find_flag_by_key(flag['key'])
+            if existing:
+                print(f"  [skip] feature flag already exists: {flag['key']}")
+                continue
+            resp = make_posthog_api_request(feature_flag_endpoint, flag)
+            if resp and 'id' in resp:
+                print(f"  [ok] created feature flag: {flag['key']}")
+            else:
+                print(f"  [warn] feature flag create returned no id: {flag['key']}")
+        except PostHogForbiddenError as e:
+            print(f"  [error] 403 creating feature flag '{flag['key']}': {e.body[:200]}")
+            print("  Hint: scope 'feature_flag:write' may be missing.")
+        except Exception as e:
+            print(f"  [error] failed creating feature flag '{flag['key']}': {e}")
+
+
+def create_experiment():
+    """Create one completed experiment: 'Free trial length: 7 days vs 14 days'.
+
+    Backed by a multivariate feature flag with control/test variants.
+    Marked completed via end_date in the past.
+    """
+    experiments_endpoint = '/experiments/'
+    exp_name = "Free trial length: 7 days vs 14 days"
+    flag_key = "free_trial_length"
+
+    try:
+        existing = _find_by_name(experiments_endpoint, exp_name)
+        if existing:
+            print(f"  [skip] experiment already exists: {exp_name}")
+            return
+
+        # PostHog creates the backing feature flag automatically when an
+        # experiment is created with `feature_flag_key`. If a flag with that
+        # key already exists (from a prior partial run), reuse it; otherwise
+        # let the experiment endpoint create it.
+        existing_flag = _find_flag_by_key(flag_key)
+
+        # Mark as completed: start in the past, end yesterday.
+        start = datetime.now(timezone.utc) - timedelta(days=30)
+        end = datetime.now(timezone.utc) - timedelta(days=1)
+
+        payload = {
+            "name": exp_name,
+            "description": "Does giving a 14-day free trial improve conversion vs 7 days?",
+            "feature_flag_key": flag_key,
+            "start_date": start.isoformat(),
+            "end_date": end.isoformat(),
+            "parameters": {
+                "feature_flag_variants": [
+                    {"key": "control", "name": "7 days", "rollout_percentage": 50},
+                    {"key": "test", "name": "14 days", "rollout_percentage": 50},
+                ],
+                "recommended_sample_size": 1000,
+                "minimum_detectable_effect": 5,
+            },
+            "filters": {
+                "events": [
+                    {"id": "subscription_purchased", "name": "subscription_purchased",
+                     "type": "events", "order": 0}
+                ],
+                "insight": "FUNNELS",
+            },
+        }
+        if existing_flag:
+            # Avoid duplicate-flag-key 400 by passing the existing flag id.
+            payload["feature_flag"] = existing_flag.get("id")
+
+        resp = make_posthog_api_request(experiments_endpoint, payload)
+        if resp and 'id' in resp:
+            print(f"  [ok] created experiment: {exp_name}")
+        else:
+            print(f"  [warn] experiment create returned no id: {exp_name}")
+    except PostHogForbiddenError as e:
+        print(f"  [error] 403 creating experiment '{exp_name}': {e.body[:200]}")
+        print("  Hint: scope 'experiment:write' may be missing.")
+    except Exception as e:
+        print(f"  [error] failed creating experiment '{exp_name}': {e}")
+
+
+def create_more_cohorts():
+    """Create additional cohorts.
+
+    - 'Power users': performed any movie_*_complete event 5+ times in 30 days.
+      Uses the existing 'Watched a movie' action as a proxy (which matches
+      pageviews to /movie/, the seed-data signal for movie completion).
+    - 'Trial bouncers': signed up but no plan_changed within 7 days.
+    - 'High-value subscribers': subscription_purchased with plan='Max-imal'.
+    - 'Defined but unused': Hogflix internal IPs (issue E5: never referenced
+      in any insight).
+    """
+    watched_a_movie_id = actions_ids.get('Watched a movie')
+
+    cohorts = [
+        {
+            "name": "Power users",
+            "description": "Watched 5+ movies in the last 30 days.",
+            "filters": {
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "type": "behavioral",
+                                    "value": "performed_event_multiple",
+                                    "key": watched_a_movie_id,
+                                    "negation": False,
+                                    "operator": "gte",
+                                    "event_type": "actions",
+                                    "operator_value": 5,
+                                    "explicit_datetime": "-30d",
+                                }
+                            ],
+                        }
+                    ],
+                }
+            },
+        },
+        {
+            "name": "Trial bouncers",
+            "description": "Hit /signup but never fired plan_changed within 7 days.",
+            "filters": {
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "type": "behavioral",
+                                    "value": "performed_event",
+                                    "key": "$pageview",
+                                    "negation": False,
+                                    "event_type": "events",
+                                    "explicit_datetime": "-30d",
+                                    "event_filters": [
+                                        {
+                                            "key": "$pathname",
+                                            "type": "event",
+                                            "value": ["/signup"],
+                                            "operator": "exact",
+                                        }
+                                    ],
+                                },
+                                {
+                                    "type": "behavioral",
+                                    "value": "performed_event",
+                                    "key": "plan_changed",
+                                    "negation": True,
+                                    "event_type": "events",
+                                    "explicit_datetime": "-7d",
+                                },
+                            ],
+                        }
+                    ],
+                }
+            },
+        },
+        {
+            "name": "High-value subscribers",
+            "description": "Bought a Max-imal subscription.",
+            "filters": {
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "type": "behavioral",
+                                    "value": "performed_event",
+                                    "key": "subscription_purchased",
+                                    "negation": False,
+                                    "event_type": "events",
+                                    "explicit_datetime": "-90d",
+                                    "event_filters": [
+                                        {
+                                            "key": "plan",
+                                            "type": "event",
+                                            "value": ["Max-imal"],
+                                            "operator": "exact",
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            },
+        },
+        {
+            "name": "Defined but unused",
+            "description": "Hogflix internal IPs. Never referenced in any insight (issue E5).",
+            "filters": {
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "OR",
+                            "values": [
+                                {
+                                    "key": "$ip",
+                                    "type": "person",
+                                    "value": ["10.0.0.0/8", "192.168.0.0/16"],
+                                    "operator": "exact",
+                                }
+                            ],
+                        }
+                    ],
+                }
+            },
+        },
+    ]
+    for cohort in cohorts:
+        try:
+            existing = _find_by_name(cohorts_endpoint, cohort['name'])
+            if existing:
+                print(f"  [skip] cohort already exists: {cohort['name']}")
+                cohorts_ids[cohort['name']] = existing['id']
+                continue
+            resp = make_posthog_api_request(cohorts_endpoint, cohort)
+            if resp and 'id' in resp:
+                cohorts_ids[cohort['name']] = resp['id']
+                print(f"  [ok] created cohort: {cohort['name']}")
+            else:
+                print(f"  [warn] cohort create returned no id: {cohort['name']}")
+        except PostHogForbiddenError as e:
+            print(f"  [error] 403 creating cohort '{cohort['name']}': {e.body[:200]}")
+            print("  Hint: scope 'cohort:write' may be missing.")
+        except Exception as e:
+            print(f"  [error] failed creating cohort '{cohort['name']}': {e}")
+
+
+# Module-level cache so create_dashboards() can reference insights created
+# by create_more_insights() by name->id.
+extra_insights_ids = {}
+
+
+def create_more_insights():
+    """Create additional insights.
+
+    Returns a dict mapping insight name -> id for the dashboards step.
+    Includes one intentionally broken insight (action id 999999, issue E6)
+    and one SQL insight that uses the wrong field name (issue C1).
+    """
+    insights = [
+        # 1. Trend: subscription_purchased per day
+        {
+            "name": "Subscriptions purchased per day",
+            "saved": True,
+            "tags": ["demo"],
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "dateRange": {"date_from": "-30d"},
+                    "series": [
+                        {"kind": "EventsNode", "event": "subscription_purchased",
+                         "name": "subscription_purchased", "math": "total"}
+                    ],
+                    "interval": "day",
+                    "trendsFilter": {"display": "ActionsLineGraph"},
+                },
+                "full": True,
+            },
+        },
+        # 2. Trend: movie_buy_complete per day
+        {
+            "name": "Movie purchases per day",
+            "saved": True,
+            "tags": ["demo"],
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "dateRange": {"date_from": "-30d"},
+                    "series": [
+                        {"kind": "EventsNode", "event": "movie_buy_complete",
+                         "name": "movie_buy_complete", "math": "total"}
+                    ],
+                    "interval": "day",
+                    "trendsFilter": {"display": "ActionsLineGraph"},
+                },
+                "full": True,
+            },
+        },
+        # 3. Funnel: subscription_intent -> subscription_purchased
+        {
+            "name": "Subscription intent to purchase funnel",
+            "saved": True,
+            "tags": ["demo"],
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "FunnelsQuery",
+                    "dateRange": {"date_from": "-30d"},
+                    "series": [
+                        {"kind": "EventsNode", "event": "subscription_intent",
+                         "name": "subscription_intent"},
+                        {"kind": "EventsNode", "event": "subscription_purchased",
+                         "name": "subscription_purchased"},
+                    ],
+                    "funnelsFilter": {"funnelVizType": "steps"},
+                },
+                "full": True,
+            },
+        },
+        # 4. Funnel: signup pageview -> subscription_purchased
+        {
+            "name": "Signup to subscription funnel",
+            "saved": True,
+            "tags": ["demo"],
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "FunnelsQuery",
+                    "dateRange": {"date_from": "-30d"},
+                    "series": [
+                        {
+                            "kind": "EventsNode", "event": "$pageview",
+                            "name": "$pageview", "custom_name": "Signup",
+                            "properties": [
+                                {"key": "$pathname", "type": "event",
+                                 "value": ["/signup"], "operator": "exact"}
+                            ],
+                        },
+                        {"kind": "EventsNode", "event": "subscription_purchased",
+                         "name": "subscription_purchased"},
+                    ],
+                    "funnelsFilter": {"funnelVizType": "steps"},
+                },
+                "full": True,
+            },
+        },
+        # 5. Retention: weekly retention by subscription_purchased
+        {
+            "name": "Weekly subscription retention",
+            "saved": True,
+            "tags": ["demo"],
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "RetentionQuery",
+                    "retentionFilter": {
+                        "retentionType": "retention_first_time",
+                        "totalIntervals": 8,
+                        "period": "Week",
+                        "targetEntity": {
+                            "id": "subscription_purchased",
+                            "name": "subscription_purchased",
+                            "type": "events",
+                            "order": 0,
+                        },
+                        "returningEntity": {
+                            "id": "subscription_purchased",
+                            "name": "subscription_purchased",
+                            "type": "events",
+                            "order": 0,
+                        },
+                    },
+                },
+                "full": True,
+            },
+        },
+        # 6. Lifecycle: user_logged_in (returning vs dormant)
+        {
+            "name": "Login lifecycle",
+            "saved": True,
+            "tags": ["demo"],
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "LifecycleQuery",
+                    "dateRange": {"date_from": "-30d"},
+                    "interval": "week",
+                    "series": [
+                        {"kind": "EventsNode", "event": "user_logged_in",
+                         "name": "user_logged_in", "math": "total"}
+                    ],
+                },
+                "full": True,
+            },
+        },
+        # 7. Stickiness: movie_*_complete by week. PostHog stickiness queries
+        # operate on a single event per series, so we use the broader
+        # 'Watched a movie' action when available (action id) to capture the
+        # family of movie events.
+        {
+            "name": "Movie watch stickiness",
+            "saved": True,
+            "tags": ["demo"],
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "StickinessQuery",
+                    "dateRange": {"date_from": "-30d"},
+                    "interval": "week",
+                    "series": [
+                        {"kind": "ActionsNode",
+                         "id": actions_ids.get('Watched a movie'),
+                         "name": "Watched a movie", "math": "total"}
+                    ],
+                    "stickinessFilter": {},
+                },
+                "full": True,
+            },
+        },
+        # 8. SQL: top movies by view count.
+        {
+            "name": "Top movies by view count",
+            "saved": True,
+            "tags": ["demo"],
+            "query": {
+                "kind": "DataTableNode",
+                "source": {
+                    "kind": "HogQLQuery",
+                    "query": (
+                        "SELECT properties.$pathname AS movie, count() AS views\n"
+                        "FROM events\n"
+                        "WHERE event = '$pageview'\n"
+                        "  AND properties.$pathname LIKE '/movie/%'\n"
+                        "  AND timestamp > now() - INTERVAL 30 DAY\n"
+                        "GROUP BY movie\n"
+                        "ORDER BY views DESC\n"
+                        "LIMIT 25"
+                    ),
+                },
+                "full": True,
+            },
+        },
+        # 9. SQL: revenue by plan tier — INTENTIONALLY uses `value` instead of
+        # `price`. The seed data writes `price` in cents; querying `value`
+        # silently returns zero/NULL across the board. Demonstrates issue C1
+        # (silent metric drift via wrong field name).
+        {
+            "name": "Revenue by plan tier (broken: wrong field)",
+            "saved": True,
+            "tags": ["demo", "broken"],
+            "query": {
+                "kind": "DataTableNode",
+                "source": {
+                    "kind": "HogQLQuery",
+                    "query": (
+                        "SELECT properties.plan AS plan,\n"
+                        "       sum(toFloat(properties.value)) / 100 AS revenue_usd\n"
+                        "FROM events\n"
+                        "WHERE event = 'subscription_purchased'\n"
+                        "  AND timestamp > now() - INTERVAL 30 DAY\n"
+                        "GROUP BY plan\n"
+                        "ORDER BY revenue_usd DESC"
+                    ),
+                },
+                "full": True,
+            },
+        },
+        # 10. Trend referencing a fake action id (issue E6: broken reference).
+        {
+            "name": "Trend with broken action reference",
+            "saved": True,
+            "tags": ["demo", "broken"],
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "dateRange": {"date_from": "-30d"},
+                    "series": [
+                        {"kind": "ActionsNode", "id": 999999,
+                         "name": "Nonexistent action", "math": "total"}
+                    ],
+                    "interval": "day",
+                    "trendsFilter": {"display": "ActionsLineGraph"},
+                },
+                "full": True,
+            },
+        },
+    ]
+    for insight in insights:
+        try:
+            existing = _find_by_name(insights_endpoint, insight['name'])
+            if existing:
+                extra_insights_ids[insight['name']] = existing['id']
+                print(f"  [skip] insight already exists: {insight['name']}")
+                continue
+            resp = make_posthog_api_request(insights_endpoint, insight)
+            if resp and 'id' in resp:
+                extra_insights_ids[insight['name']] = resp['id']
+                print(f"  [ok] created insight: {insight['name']}")
+            else:
+                print(f"  [warn] insight create returned no id: {insight['name']}")
+        except PostHogForbiddenError as e:
+            print(f"  [error] 403 creating insight '{insight['name']}': {e.body[:200]}")
+            print("  Hint: scope 'insight:write' may be missing.")
+        except Exception as e:
+            print(f"  [error] failed creating insight '{insight['name']}': {e}")
+
+
+def create_dashboards():
+    """Create demo dashboards and attach insight tiles.
+
+    Customer health (insights 1-7): subs/day, movie buys/day, intent funnel,
+    signup funnel, weekly retention, login lifecycle, movie stickiness.
+    Revenue (insights 8-9): top movies SQL + broken revenue SQL.
+    """
+    dashboards_endpoint = '/dashboards/'
+    tiles_endpoint = '/dashboard_tiles/'
+
+    customer_health_names = [
+        "Subscriptions purchased per day",
+        "Movie purchases per day",
+        "Subscription intent to purchase funnel",
+        "Signup to subscription funnel",
+        "Weekly subscription retention",
+        "Login lifecycle",
+        "Movie watch stickiness",
+    ]
+    revenue_names = [
+        "Top movies by view count",
+        "Revenue by plan tier (broken: wrong field)",
+    ]
+
+    plan = [
+        ("Customer health", "Onboarding & retention demo dashboard.", customer_health_names),
+        ("Revenue", "Revenue tracking demo dashboard. Includes one broken SQL insight (issue C1).", revenue_names),
+    ]
+
+    for dash_name, dash_desc, insight_names in plan:
+        try:
+            existing = _find_by_name(dashboards_endpoint, dash_name)
+            if existing:
+                dashboard_id = existing['id']
+                print(f"  [skip] dashboard already exists: {dash_name} (id={dashboard_id})")
+            else:
+                resp = make_posthog_api_request(dashboards_endpoint, {
+                    "name": dash_name,
+                    "description": dash_desc,
+                    "tags": ["demo"],
+                })
+                if not (resp and 'id' in resp):
+                    print(f"  [warn] dashboard create returned no id: {dash_name}")
+                    continue
+                dashboard_id = resp['id']
+                print(f"  [ok] created dashboard: {dash_name} (id={dashboard_id})")
+
+            # Attach insights as tiles. Skip insights that aren't in the
+            # cache (e.g. failed earlier).
+            for iname in insight_names:
+                insight_id = extra_insights_ids.get(iname)
+                if not insight_id:
+                    print(f"    [skip-tile] missing insight '{iname}'")
+                    continue
+                # Two paths exist for adding tiles: PATCH the dashboard with
+                # tile_layouts, or POST to /dashboard_tiles/. The tiles
+                # endpoint is simpler and idempotent on (dashboard, insight).
+                tile_payload = {
+                    "dashboard": dashboard_id,
+                    "insight": insight_id,
+                }
+                try:
+                    resp = requests.post(url + tiles_endpoint, headers=headers,
+                                         json=tile_payload, timeout=30)
+                    if resp.status_code in (200, 201):
+                        print(f"    [ok] tiled '{iname}' on '{dash_name}'")
+                    elif resp.status_code == 404:
+                        # Older PostHog versions don't expose dashboard_tiles
+                        # directly; fall back to PATCHing the insight to
+                        # include this dashboard.
+                        patch_url = f"{url}{insights_endpoint}{insight_id}/"
+                        patch_resp = requests.patch(
+                            patch_url, headers=headers,
+                            json={"dashboards": [dashboard_id]}, timeout=30
+                        )
+                        if patch_resp.status_code in (200, 201):
+                            print(f"    [ok] tiled '{iname}' on '{dash_name}' (via insight patch)")
+                        else:
+                            print(f"    [warn] could not tile '{iname}': "
+                                  f"tiles={resp.status_code} patch={patch_resp.status_code}")
+                    else:
+                        print(f"    [warn] tile create returned {resp.status_code}: "
+                              f"{(resp.text or '')[:200]}")
+                except Exception as e:
+                    print(f"    [error] tiling '{iname}' on '{dash_name}': {e}")
+        except PostHogForbiddenError as e:
+            print(f"  [error] 403 creating dashboard '{dash_name}': {e.body[:200]}")
+            print("  Hint: scope 'dashboard:write' may be missing.")
+        except Exception as e:
+            print(f"  [error] failed creating dashboard '{dash_name}': {e}")
+
+
+# --- run extended creation steps in order. Each is wrapped so a single
+# failure does not abort the whole run. ---
+print("\n--- creating surveys ---")
+try:
+    create_surveys()
+except Exception as e:
+    print(f"  [error] create_surveys() top-level failure: {e}")
+
+print("\n--- creating additional feature flags ---")
+try:
+    create_more_feature_flags()
+except Exception as e:
+    print(f"  [error] create_more_feature_flags() top-level failure: {e}")
+
+print("\n--- creating experiment ---")
+try:
+    create_experiment()
+except Exception as e:
+    print(f"  [error] create_experiment() top-level failure: {e}")
+
+print("\n--- creating additional cohorts ---")
+try:
+    create_more_cohorts()
+except Exception as e:
+    print(f"  [error] create_more_cohorts() top-level failure: {e}")
+
+print("\n--- creating additional insights ---")
+try:
+    create_more_insights()
+except Exception as e:
+    print(f"  [error] create_more_insights() top-level failure: {e}")
+
+print("\n--- creating dashboards ---")
+try:
+    create_dashboards()
+except Exception as e:
+    print(f"  [error] create_dashboards() top-level failure: {e}")
+
+print("\n--- done ---")

--- a/scripts/create_posthog_artifacts.py
+++ b/scripts/create_posthog_artifacts.py
@@ -1,9 +1,147 @@
 import requests
+import sys
 from argparse import ArgumentParser
 import os
 from dotenv import load_dotenv
 from pathlib import Path
 from urllib.parse import quote
+
+REQUIRED_SCOPES = [
+    "action:write",
+    "cohort:write",
+    "dashboard:write",
+    "experiment:write",
+    "feature_flag:write",
+    "insight:write",
+    "query:read",
+    "survey:write",
+]
+
+
+def precheck_scopes(api_key):
+    """Verify the Personal API key has all required scopes before doing any work.
+
+    Strategy:
+    1. Hit GET /api/users/@me/ and look for an explicit scopes list on the user
+       or the key. PostHog versions vary in where this surfaces (top-level,
+       under `team`, under `organization`, or as a `scoped_*` field), so we
+       search broadly.
+    2. If no scopes can be discovered that way, fall back to a cheap probe:
+       POST /api/projects/<project_id>/cohorts/ with an empty body. A 403 on
+       a scope check returns a `detail` like "API key missing required scope
+       'cohort:write'.". We parse that and surface the missing scopes.
+
+    On any missing scopes, print a clear, actionable error and exit 1.
+    """
+    auth_headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    base_host = host.replace(".i.posthog.com", ".posthog.com")
+    discovered_scopes = None
+
+    # Step 1: try /api/users/@me/
+    try:
+        me_resp = requests.get(f"{base_host}/api/users/@me/", headers=auth_headers, timeout=15)
+        if me_resp.status_code == 401:
+            print("ERROR: Personal API key is invalid or expired (HTTP 401 on /api/users/@me/).")
+            print("Update at: https://us.posthog.com/settings/user-api-keys")
+            sys.exit(1)
+        if me_resp.status_code == 200:
+            payload = me_resp.json() if me_resp.content else {}
+            # Search common locations for a scopes list.
+            candidates = []
+            if isinstance(payload, dict):
+                for key in ("scopes", "scoped_scopes", "key_scopes"):
+                    val = payload.get(key)
+                    if isinstance(val, list):
+                        candidates.extend(val)
+                # Some versions nest the key info under `personal_api_key` or similar.
+                for nest_key in ("personal_api_key", "api_key", "current_key"):
+                    nested = payload.get(nest_key)
+                    if isinstance(nested, dict):
+                        nv = nested.get("scopes")
+                        if isinstance(nv, list):
+                            candidates.extend(nv)
+            if candidates:
+                discovered_scopes = set(candidates)
+    except requests.RequestException as e:
+        print(f"ERROR: could not reach PostHog at {base_host} during scope precheck: {e}")
+        sys.exit(1)
+
+    missing = []
+
+    if discovered_scopes is not None:
+        # Wildcard "*" grants everything in PostHog scope conventions.
+        if "*" in discovered_scopes:
+            missing = []
+        else:
+            missing = [s for s in REQUIRED_SCOPES if s not in discovered_scopes]
+    else:
+        # Step 2: fall back to a cheap probe. POST an empty cohort body and
+        # parse the 403 detail message for missing-scope hints.
+        probe_url = f"{base_host}/api/projects/{project_id}/cohorts/"
+        try:
+            probe = requests.post(probe_url, headers=auth_headers, json={}, timeout=15)
+        except requests.RequestException as e:
+            print(f"ERROR: could not reach PostHog at {base_host} during scope precheck: {e}")
+            sys.exit(1)
+
+        if probe.status_code == 403:
+            try:
+                detail = probe.json().get("detail", "") or ""
+            except ValueError:
+                detail = probe.text or ""
+            # Probe only tests cohort:write. If THAT scope is missing, surface it.
+            # Otherwise we cannot infer the rest from one probe — assume key is
+            # too narrow and warn the user to grant all required scopes.
+            if "cohort:write" in detail or "scope" in detail.lower():
+                # Could be exactly cohort:write, or could be a generic "missing scope" reply.
+                # Be conservative: report all required scopes as unverifiable.
+                if "cohort:write" in detail:
+                    missing = ["cohort:write"]
+                else:
+                    missing = list(REQUIRED_SCOPES)
+            else:
+                # 403 for a non-scope reason (e.g., project access). Treat as fatal.
+                print("ERROR: Personal API key is forbidden from accessing this project (HTTP 403).")
+                print(f"  detail: {detail}")
+                print("Update at: https://us.posthog.com/settings/user-api-keys")
+                sys.exit(1)
+        elif probe.status_code in (400, 422):
+            # Empty body rejected on validation grounds — auth + scope are fine for cohort:write.
+            # We still cannot verify the other scopes; warn the user we could not enumerate.
+            print(
+                "WARNING: could not enumerate Personal API key scopes via /api/users/@me/; "
+                "cohort:write probe succeeded but other scopes are unverified. "
+                "If a later request 403s, re-check scopes at "
+                "https://us.posthog.com/settings/user-api-keys"
+            )
+            missing = []
+        elif probe.status_code in (200, 201):
+            # Unexpectedly created something — try to clean up but don't block on it.
+            missing = []
+            try:
+                created = probe.json()
+                cid = created.get("id") if isinstance(created, dict) else None
+                if cid:
+                    requests.delete(f"{probe_url}{cid}/", headers=auth_headers, timeout=15)
+            except Exception:
+                pass
+        else:
+            print(
+                f"ERROR: unexpected response during scope precheck (HTTP {probe.status_code}). "
+                f"Body: {probe.text[:300]}"
+            )
+            sys.exit(1)
+
+    if missing:
+        print("ERROR: Personal API key is missing required scope(s):")
+        for s in missing:
+            print(f"  - {s}")
+        print("Update at: https://us.posthog.com/settings/user-api-keys")
+        sys.exit(1)
+
 
 parser = ArgumentParser()
 parser.add_argument("-k", "--personal_api_key",
@@ -418,16 +556,53 @@ feature_flag_data = {
             }
         }
 
+class PostHogForbiddenError(Exception):
+    """Raised when PostHog returns 403 on an artifact-creation call.
+
+    Carries the endpoint and response body so the caller can hint at the
+    likely missing scope.
+    """
+
+    def __init__(self, endpoint, status_code, body):
+        self.endpoint = endpoint
+        self.status_code = status_code
+        self.body = body
+        super().__init__(f"HTTP {status_code} on {endpoint}: {body[:300]}")
+
+
 def make_posthog_api_request(endpoint, data):
     response = requests.post(url + endpoint, headers=headers, json=data)
     if response.status_code == 201:
         return response.json()
+    if response.status_code == 403:
+        raise PostHogForbiddenError(endpoint, response.status_code, response.text or "")
     print(f"Request failed with status code {response.status_code}")
     print("Response:", response.text)
     try:
         return response.json()
     except Exception:
         return None
+
+
+# Map of endpoint -> the scope most likely required to write to it.
+ENDPOINT_SCOPE_HINTS = {
+    '/actions/': 'action:write',
+    '/cohorts/': 'cohort:write',
+    '/insights/': 'insight:write',
+    '/feature_flags/': 'feature_flag:write',
+    '/dashboards/': 'dashboard:write',
+    '/experiments/': 'experiment:write',
+    '/surveys/': 'survey:write',
+}
+
+
+def report_403_and_reraise(err, action_label):
+    """Print a clear scope hint for a 403 and re-raise the original exception."""
+    hint = ENDPOINT_SCOPE_HINTS.get(err.endpoint, 'unknown')
+    print(f"ERROR: HTTP 403 while {action_label} (endpoint {err.endpoint}).")
+    print(f"  scope '{hint}' is likely missing from the Personal API key.")
+    print("  Update at: https://us.posthog.com/settings/user-api-keys")
+    raise err
 
 
 def get_existing_by(endpoint, match_key, match_value):
@@ -444,54 +619,73 @@ def get_existing_by(endpoint, match_key, match_value):
         return None
     return None
 
+# Verify the Personal API key has all required scopes BEFORE any artifact work.
+precheck_scopes(personal_api_key)
+
 # Making the POST request
 
-for data in actions_data:
-    # Try to find existing action by name
-    existing = get_existing_by(actions_endpoint, 'name', data['name'])
-    if existing:
-        actions_ids[data['name']] = existing['id']
-        continue
-    response = make_posthog_api_request(actions_endpoint, data)
-    if response and 'id' in response:
-        actions_ids[data['name']] = response['id']
+# --- actions ---
+try:
+    for data in actions_data:
+        # Try to find existing action by name
+        existing = get_existing_by(actions_endpoint, 'name', data['name'])
+        if existing:
+            actions_ids[data['name']] = existing['id']
+            continue
+        response = make_posthog_api_request(actions_endpoint, data)
+        if response and 'id' in response:
+            actions_ids[data['name']] = response['id']
+except PostHogForbiddenError as e:
+    report_403_and_reraise(e, "creating actions")
 
 cohorts_data[1]['filters']['properties']['values'][0]['values'][0]['key'] =  actions_ids.get('Watched a movie')
 cohorts_data[2]['filters']['properties']['values'][0]['values'][0]['key'] =  actions_ids.get('Watched a movie')
 
-for data in cohorts_data:
-    existing = get_existing_by(cohorts_endpoint, 'name', data['name'])
-    if existing:
-        cohorts_ids[data['name']] = existing['id']
-        continue
-    response = make_posthog_api_request(cohorts_endpoint, data)
-    if response and 'id' in response:
-        cohorts_ids[data['name']] = response['id']
+# --- cohorts ---
+try:
+    for data in cohorts_data:
+        existing = get_existing_by(cohorts_endpoint, 'name', data['name'])
+        if existing:
+            cohorts_ids[data['name']] = existing['id']
+            continue
+        response = make_posthog_api_request(cohorts_endpoint, data)
+        if response and 'id' in response:
+            cohorts_ids[data['name']] = response['id']
+except PostHogForbiddenError as e:
+    report_403_and_reraise(e, "creating cohorts")
 
-movie_views_trend_data['query']['source']['series'][0]['id'] = actions_ids.get('Watched a movie')
-existing_mv = get_existing_by(insights_endpoint, 'name', movie_views_trend_data['name'])
-if not existing_mv:
-    response = make_posthog_api_request(insights_endpoint, movie_views_trend_data)
+# --- insights ---
+try:
+    movie_views_trend_data['query']['source']['series'][0]['id'] = actions_ids.get('Watched a movie')
+    existing_mv = get_existing_by(insights_endpoint, 'name', movie_views_trend_data['name'])
+    if not existing_mv:
+        response = make_posthog_api_request(insights_endpoint, movie_views_trend_data)
 
-purchase_funnel_data['query']['source']['series'][3]['id'] = actions_ids.get('Paid Plan Purchase')
-existing_pf = get_existing_by(insights_endpoint, 'name', purchase_funnel_data['name'])
-if not existing_pf:
-    response = make_posthog_api_request(insights_endpoint, purchase_funnel_data)
+    purchase_funnel_data['query']['source']['series'][3]['id'] = actions_ids.get('Paid Plan Purchase')
+    existing_pf = get_existing_by(insights_endpoint, 'name', purchase_funnel_data['name'])
+    if not existing_pf:
+        response = make_posthog_api_request(insights_endpoint, purchase_funnel_data)
 
-movie_retention_data['query']['source']['retentionFilter']['targetEntity']['id'] = actions_ids.get('Watched a movie')
-movie_retention_data['query']['source']['retentionFilter']['returningEntity']['id'] = actions_ids.get('Watched a movie')
+    movie_retention_data['query']['source']['retentionFilter']['targetEntity']['id'] = actions_ids.get('Watched a movie')
+    movie_retention_data['query']['source']['retentionFilter']['returningEntity']['id'] = actions_ids.get('Watched a movie')
 
-existing_ret = get_existing_by(insights_endpoint, 'name', movie_retention_data['name'])
-if not existing_ret:
-    response = make_posthog_api_request(insights_endpoint, movie_retention_data)
+    existing_ret = get_existing_by(insights_endpoint, 'name', movie_retention_data['name'])
+    if not existing_ret:
+        response = make_posthog_api_request(insights_endpoint, movie_retention_data)
 
-existing_path = get_existing_by(insights_endpoint, 'name', path_data['name'])
-if not existing_path:
-    response = make_posthog_api_request(insights_endpoint, path_data)
+    existing_path = get_existing_by(insights_endpoint, 'name', path_data['name'])
+    if not existing_path:
+        response = make_posthog_api_request(insights_endpoint, path_data)
+except PostHogForbiddenError as e:
+    report_403_and_reraise(e, "creating insights")
 
-feature_flag_data['filters']['groups'][0]['properties'][0]['value'] = cohorts_ids.get('Adult Subscribers')
-existing_ff = get_existing_by(feature_flag_endpoint, 'key', feature_flag_data['key'])
-if not existing_ff:
-    response = make_posthog_api_request(feature_flag_endpoint, feature_flag_data)
+# --- feature flag ---
+try:
+    feature_flag_data['filters']['groups'][0]['properties'][0]['value'] = cohorts_ids.get('Adult Subscribers')
+    existing_ff = get_existing_by(feature_flag_endpoint, 'key', feature_flag_data['key'])
+    if not existing_ff:
+        response = make_posthog_api_request(feature_flag_endpoint, feature_flag_data)
+except PostHogForbiddenError as e:
+    report_403_and_reraise(e, "creating feature flag")
 
 

--- a/scripts/seed_demo_data.py
+++ b/scripts/seed_demo_data.py
@@ -32,6 +32,11 @@ from scripts.seed_helpers.cost_amplifiers import (
     double_fire_purchase,
     anonymous_profile_creation,
 )
+from scripts.seed_helpers.identity_issues import (
+    maybe_identify_user,
+    unstable_distinct_ids,
+    flag_flip_pattern,
+)
 
 # The PostHog Python SDK injects host-machine $os/$os_version into every event,
 # overriding caller-supplied values. Strip those keys from the SDK's system
@@ -265,9 +270,12 @@ def get_client_properties(user = None):
       }
    return properties
 
+_identified_users = set()
+
+
 def browse_and_watch_movie(number = 1, user=None, day_offset=None):
    fake_user = user or random.choice(fake_users)
-   distinct_id = fake_user['email']
+   base_distinct_id = fake_user['email']
    family_id = fake_user['family_id']
    family_name = fake_user['last_name']
 
@@ -275,9 +283,25 @@ def browse_and_watch_movie(number = 1, user=None, day_offset=None):
 
    groups = {'family': family_id}
 
+   # B3 identity instability: ~5% of users have 2-3 distinct_ids; per session we
+   # pick one of them. Across multiple sessions the same user lands on different
+   # IDs, so PostHog sees them as separate persons (no alias, no merge).
+   distinct_id_pool = unstable_distinct_ids(fake_user, base_distinct_id)
+   distinct_id = random.choice(distinct_id_pool)
+
    for i in range(random.randint(1, number)):
         timestamp = get_random_time(day_offset=day_offset)
         client_properties = get_client_properties(user=fake_user)
+
+        # B1 partial identification: ~10% of users ever get identified.
+        if base_distinct_id not in _identified_users:
+            if maybe_identify_user(posthog, fake_user, distinct_id, timestamp,
+                                   client_properties, probability=0.10, groups=groups):
+                _identified_users.add(base_distinct_id)
+
+        # B4 flag flip: ~5% of users emit a 3-event flip-flop pattern at session start.
+        flag_flip_pattern(posthog, fake_user, distinct_id, timestamp,
+                          client_properties, groups=groups)
 
         # A4 cost amplifier: $feature_flag_called flood once per session for
         # ~30% of sessions (action_mode_on flag re-evaluated 4x in a tight loop).

--- a/scripts/seed_demo_data.py
+++ b/scripts/seed_demo_data.py
@@ -24,6 +24,14 @@ from scripts.seed_helpers.autocapture import (
     synthesize_dead_click,
 )
 from scripts.seed_helpers.exceptions import synthesize_exception
+from scripts.seed_helpers.cost_amplifiers import (
+    spam_pageleave,
+    spam_groupidentify,
+    flag_eval_flood,
+    identify_spam,
+    double_fire_purchase,
+    anonymous_profile_creation,
+)
 
 # The PostHog Python SDK injects host-machine $os/$os_version into every event,
 # overriding caller-supplied values. Strip those keys from the SDK's system
@@ -152,9 +160,10 @@ def _user_id_int(email):
     return abs(hash(email)) & 0x7FFFFFFF
 
 
-def sprinkle_clicks_on_page(distinct_id, page, base_timestamp, client_properties, groups=None):
+def sprinkle_clicks_on_page(distinct_id, page, base_timestamp, client_properties, groups=None, family_id=None, family_name=None):
     """Emit a few $autocapture clicks (and rare $rageclick / $dead_click) for the
-    page the user just landed on, with second-level offsets after the pageview."""
+    page the user just landed on, plus the cost-amplifier patterns: $pageleave
+    spam (3x), $groupidentify spam (re-fires each pageview)."""
     n_clicks = random.randint(1, 4)
     for i in range(n_clicks):
         synthesize_autocapture(
@@ -177,6 +186,14 @@ def sprinkle_clicks_on_page(distinct_id, page, base_timestamp, client_properties
             timestamp=base_timestamp + timedelta(seconds=25),
             session_props=client_properties, groups=groups or {},
         )
+    # A6/A2 cost amplifiers: $pageleave fires 3x per pageview; $groupidentify
+    # re-fires after every pageview when the user is in a family group.
+    spam_pageleave(posthog, distinct_id, page, base_timestamp + timedelta(seconds=2),
+                   client_properties, count=3, groups=groups or {})
+    if family_id is not None:
+        spam_groupidentify(posthog, distinct_id, 'family', family_id,
+                           {'name': family_name or ''},
+                           base_timestamp + timedelta(seconds=1))
 
 
 def maybe_emit_exception(distinct_id, base_timestamp, client_properties, groups=None, probability=0.03):
@@ -251,30 +268,50 @@ def get_client_properties(user = None):
 def browse_and_watch_movie(number = 1, user=None, day_offset=None):
    fake_user = user or random.choice(fake_users)
    distinct_id = fake_user['email']
+   family_id = fake_user['family_id']
+   family_name = fake_user['last_name']
 
-   posthog.group_identify('family', fake_user['family_id'], {
-      'name': fake_user['last_name']
-   })
+   posthog.group_identify('family', family_id, {'name': family_name})
 
-   groups = {'family': fake_user['family_id']}
+   groups = {'family': family_id}
 
    for i in range(random.randint(1, number)):
         timestamp = get_random_time(day_offset=day_offset)
         client_properties = get_client_properties(user=fake_user)
-        
+
+        # A4 cost amplifier: $feature_flag_called flood once per session for
+        # ~30% of sessions (action_mode_on flag re-evaluated 4x in a tight loop).
+        if random.random() < 0.3:
+            flag_eval_flood(posthog, distinct_id, ['action_mode_on'],
+                            timestamp + timedelta(seconds=1),
+                            client_properties, flood_count=4, groups=groups)
+
+        # B2 identify spam: ~10% of sessions emit identify() five times.
+        if random.random() < 0.10:
+            identify_spam(posthog, distinct_id,
+                          timestamp,
+                          properties_to_set={
+                              'email': fake_user['email'],
+                              'plan': fake_user['plan'],
+                              'is_adult': fake_user['is_adult'],
+                          },
+                          count=5)
+
         capture_event(event='user_logged_in', extra_properties=client_properties, timestamp=timestamp, distinct_id=distinct_id, groups=groups)
 
         timestamp = timestamp + timedelta(minutes=random.randint(1,5))
 
         capture_pageview(url='https://hogflix.net/', client_properties = client_properties,timestamp=timestamp, distinct_id = distinct_id, groups=groups)
-        sprinkle_clicks_on_page(distinct_id, '/', timestamp, client_properties, groups)
+        sprinkle_clicks_on_page(distinct_id, '/', timestamp, client_properties, groups,
+                                family_id=family_id, family_name=family_name)
 
         movie_id = random.randint(1,3)
 
         timestamp = timestamp + timedelta(minutes=random.randint(1,15))
 
         capture_pageview(url=f'https://hogflix.net/movie/{movie_id}', client_properties = client_properties, timestamp=timestamp, distinct_id = distinct_id, groups=groups)
-        sprinkle_clicks_on_page(distinct_id, f'/movie/{movie_id}', timestamp, client_properties, groups)
+        sprinkle_clicks_on_page(distinct_id, f'/movie/{movie_id}', timestamp, client_properties, groups,
+                                family_id=family_id, family_name=family_name)
         maybe_emit_exception(distinct_id, timestamp, client_properties, groups)
 
         # Simulate occasional revenue events
@@ -322,6 +359,10 @@ def anon_browse_homepage_and_plans(day_offset=None):
 
    timestamp = get_random_time(day_offset=day_offset)
 
+   # A6 cost amplifier: anonymous browse session creates a billed person profile
+   # (mimics the customer running with person_profiles='always').
+   anonymous_profile_creation(posthog, distinct_id, timestamp, client_properties)
+
    capture_pageview(url='https://hogflix.net/', client_properties = client_properties,timestamp=timestamp, distinct_id = distinct_id)
    sprinkle_clicks_on_page(distinct_id, '/', timestamp, client_properties)
 
@@ -344,26 +385,35 @@ def browse_plans_and_signup(user=None, day_offset=None):
    fake_user = user or random.choice(fake_users)
    client_properties = get_client_properties(user=fake_user)
    distinct_id = fake_user['email']
+   family_id = fake_user['family_id']
+   family_name = fake_user['last_name']
    timestamp = get_random_time(day_offset=day_offset)
 
-   posthog.group_identify('family', fake_user['family_id'], {
-      'name': fake_user['last_name']
-   })
-    
-   groups = {'family': fake_user['family_id']}
+   posthog.group_identify('family', family_id, {'name': family_name})
+
+   groups = {'family': family_id}
+
+   # A4 cost amplifier: flag eval flood at session start.
+   if random.random() < 0.3:
+       flag_eval_flood(posthog, distinct_id, ['action_mode_on'],
+                       timestamp + timedelta(seconds=1),
+                       client_properties, flood_count=4, groups=groups)
 
    capture_pageview(url='https://hogflix.net/', client_properties = client_properties,timestamp=timestamp, distinct_id = distinct_id, groups=groups)
-   sprinkle_clicks_on_page(distinct_id, '/', timestamp, client_properties, groups)
+   sprinkle_clicks_on_page(distinct_id, '/', timestamp, client_properties, groups,
+                           family_id=family_id, family_name=family_name)
 
    timestamp = timestamp + timedelta(minutes=random.randint(1,10))
 
    capture_pageview(url=f'https://hogflix.net/plans', client_properties = client_properties, timestamp=timestamp, distinct_id = distinct_id, groups=groups)
-   sprinkle_clicks_on_page(distinct_id, '/plans', timestamp, client_properties, groups)
+   sprinkle_clicks_on_page(distinct_id, '/plans', timestamp, client_properties, groups,
+                           family_id=family_id, family_name=family_name)
 
    timestamp = timestamp + timedelta(minutes=random.randint(1,10))
 
    capture_pageview(url=f'https://hogflix.net/signup', client_properties = client_properties, timestamp=timestamp, distinct_id = distinct_id, groups=groups)
-   sprinkle_clicks_on_page(distinct_id, '/signup', timestamp, client_properties, groups)
+   sprinkle_clicks_on_page(distinct_id, '/signup', timestamp, client_properties, groups,
+                           family_id=family_id, family_name=family_name)
    maybe_emit_exception(distinct_id, timestamp, client_properties, groups)
 
    timestamp = timestamp + timedelta(minutes=random.randint(1,10))
@@ -392,13 +442,17 @@ def browse_plans_and_signup(user=None, day_offset=None):
    }, timestamp=timestamp, distinct_id=distinct_id, groups=groups)
 
    timestamp = timestamp + timedelta(minutes=1)
-   capture_event(event='subscription_purchased', extra_properties={
+   purchase_props = {
+      "timestamp": timestamp,
       **client_properties,
       'plan': new_plan,
       'months': months,
       'price': int(round(price_dollars * 100)),
       'currency': 'USD',
-   }, timestamp=timestamp, distinct_id=distinct_id, groups=groups)
+   }
+   # A5 cost amplifier: double-fire subscription_purchased.
+   double_fire_purchase(posthog, distinct_id, 'subscription_purchased',
+                        purchase_props, timestamp, groups=groups)
 
 total_days = int(args.number_of_days)
 

--- a/scripts/seed_demo_data.py
+++ b/scripts/seed_demo_data.py
@@ -4,10 +4,32 @@ from faker import Faker
 from argparse import ArgumentParser
 import random
 import csv
+import sys
 from argparse import ArgumentParser
 from pathlib import Path
 import os
 from dotenv import load_dotenv
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from scripts.seed_helpers.browser_context import make_session_properties
+
+# The PostHog Python SDK injects host-machine $os/$os_version into every event,
+# overriding caller-supplied values. Strip those keys from the SDK's system
+# context so the per-session device profile wins. ($python_runtime/$python_version
+# stay; they're harmless metadata.)
+import posthog.client as _ph_client
+_original_system_context = _ph_client.system_context
+def _system_context_without_os():
+    ctx = dict(_original_system_context())
+    ctx.pop("$os", None)
+    ctx.pop("$os_version", None)
+    return ctx
+_ph_client.system_context = _system_context_without_os
+
+
+def _hash_seed(value):
+    """Stable positive 31-bit int seed from any value."""
+    return abs(hash(str(value))) & 0x7FFFFFFF
 
 days_to_generate = 30
 number_of_iterations = 100
@@ -144,11 +166,13 @@ def capture_event(event, extra_properties, timestamp, distinct_id, groups = {}):
   )
 
 def get_client_properties(user = None):
+   session_id = fake.uuid4()
+   session_props = make_session_properties(_hash_seed(session_id))
    if (user is not None):
       properties= {
-         **random.choice(device_properties),
+         **session_props,
          "$ip": user['ip'],
-         "$session_id": fake.uuid4(),
+         "$session_id": session_id,
          "$active_feature_flags": ["action_mode_on"],
          "$feature/action_mode_on": True if user['is_adult'] == 'Yes' else False,
          "$set": {
@@ -159,9 +183,9 @@ def get_client_properties(user = None):
       }
    else:
       properties= {
-         **random.choice(device_properties),
+         **session_props,
          "$ip": fake.ipv4_public(),
-         "$session_id": fake.uuid4(),
+         "$session_id": session_id,
          "$active_feature_flags": ["action_mode_on"],
          "$feature/action_mode_on": random.choice([True,False])
       }
@@ -169,18 +193,17 @@ def get_client_properties(user = None):
 
 def browse_and_watch_movie(number = 1):
    fake_user = random.choice(fake_users)
-   client_properties = get_client_properties(user=fake_user)
    distinct_id = fake_user['email']
 
    posthog.group_identify('family', fake_user['family_id'], {
       'name': fake_user['last_name']
    })
-    
+
    groups = {'family': fake_user['family_id']}
 
    for i in range(random.randint(1, number)):
         timestamp = get_random_time()
-        client_properties["$session_id"]=fake.uuid4()
+        client_properties = get_client_properties(user=fake_user)
         
         capture_event(event='user_logged_in', extra_properties=client_properties, timestamp=timestamp, distinct_id=distinct_id, groups=groups)
 

--- a/scripts/seed_demo_data.py
+++ b/scripts/seed_demo_data.py
@@ -18,6 +18,12 @@ from scripts.seed_helpers.growth import (
     events_per_session,
     is_user_active_on_day,
 )
+from scripts.seed_helpers.autocapture import (
+    synthesize_autocapture,
+    synthesize_rageclick,
+    synthesize_dead_click,
+)
+from scripts.seed_helpers.exceptions import synthesize_exception
 
 # The PostHog Python SDK injects host-machine $os/$os_version into every event,
 # overriding caller-supplied values. Strip those keys from the SDK's system
@@ -145,6 +151,45 @@ def _user_id_int(email):
     """Stable positive int per email for behavioral_profile()."""
     return abs(hash(email)) & 0x7FFFFFFF
 
+
+def sprinkle_clicks_on_page(distinct_id, page, base_timestamp, client_properties, groups=None):
+    """Emit a few $autocapture clicks (and rare $rageclick / $dead_click) for the
+    page the user just landed on, with second-level offsets after the pageview."""
+    n_clicks = random.randint(1, 4)
+    for i in range(n_clicks):
+        synthesize_autocapture(
+            posthog,
+            distinct_id=distinct_id,
+            page=page,
+            timestamp=base_timestamp + timedelta(seconds=5 + i * 7),
+            session_props=client_properties,
+            groups=groups or {},
+        )
+    if random.random() < 0.01:
+        synthesize_rageclick(
+            posthog, distinct_id=distinct_id, page=page,
+            timestamp=base_timestamp + timedelta(seconds=20),
+            session_props=client_properties, groups=groups or {},
+        )
+    if random.random() < 0.005:
+        synthesize_dead_click(
+            posthog, distinct_id=distinct_id, page=page,
+            timestamp=base_timestamp + timedelta(seconds=25),
+            session_props=client_properties, groups=groups or {},
+        )
+
+
+def maybe_emit_exception(distinct_id, base_timestamp, client_properties, groups=None, probability=0.03):
+    """~3% of sessions emit an $exception event."""
+    if random.random() < probability:
+        synthesize_exception(
+            posthog,
+            distinct_id=distinct_id,
+            timestamp=base_timestamp + timedelta(seconds=random.randint(10, 60)),
+            session_props=client_properties,
+            groups=groups or {},
+        )
+
 def capture_pageview(url, timestamp, client_properties, distinct_id, groups = {}):
    properties = {
       "$current_url": url,
@@ -222,12 +267,15 @@ def browse_and_watch_movie(number = 1, user=None, day_offset=None):
         timestamp = timestamp + timedelta(minutes=random.randint(1,5))
 
         capture_pageview(url='https://hogflix.net/', client_properties = client_properties,timestamp=timestamp, distinct_id = distinct_id, groups=groups)
+        sprinkle_clicks_on_page(distinct_id, '/', timestamp, client_properties, groups)
 
         movie_id = random.randint(1,3)
 
         timestamp = timestamp + timedelta(minutes=random.randint(1,15))
 
         capture_pageview(url=f'https://hogflix.net/movie/{movie_id}', client_properties = client_properties, timestamp=timestamp, distinct_id = distinct_id, groups=groups)
+        sprinkle_clicks_on_page(distinct_id, f'/movie/{movie_id}', timestamp, client_properties, groups)
+        maybe_emit_exception(distinct_id, timestamp, client_properties, groups)
 
         # Simulate occasional revenue events
         if random.randrange(100) < 25:
@@ -275,17 +323,22 @@ def anon_browse_homepage_and_plans(day_offset=None):
    timestamp = get_random_time(day_offset=day_offset)
 
    capture_pageview(url='https://hogflix.net/', client_properties = client_properties,timestamp=timestamp, distinct_id = distinct_id)
-   
+   sprinkle_clicks_on_page(distinct_id, '/', timestamp, client_properties)
+
    timestamp = timestamp + timedelta(minutes=random.randint(1,10))
-   
+
    capture_pageview(url=f'https://hogflix.net/plans', client_properties = client_properties, timestamp=timestamp, distinct_id = distinct_id)
+   sprinkle_clicks_on_page(distinct_id, '/plans', timestamp, client_properties)
 
    if random.randrange(100) < 40:
+      maybe_emit_exception(distinct_id, timestamp, client_properties)
       return None
 
    timestamp = timestamp + timedelta(minutes=random.randint(1,10))
-   
+
    capture_pageview(url=f'https://hogflix.net/signup', client_properties = client_properties, timestamp=timestamp, distinct_id = distinct_id)
+   sprinkle_clicks_on_page(distinct_id, '/signup', timestamp, client_properties)
+   maybe_emit_exception(distinct_id, timestamp, client_properties)
 
 def browse_plans_and_signup(user=None, day_offset=None):
    fake_user = user or random.choice(fake_users)
@@ -300,17 +353,21 @@ def browse_plans_and_signup(user=None, day_offset=None):
    groups = {'family': fake_user['family_id']}
 
    capture_pageview(url='https://hogflix.net/', client_properties = client_properties,timestamp=timestamp, distinct_id = distinct_id, groups=groups)
-   
-   timestamp = timestamp + timedelta(minutes=random.randint(1,10))
-   
-   capture_pageview(url=f'https://hogflix.net/plans', client_properties = client_properties, timestamp=timestamp, distinct_id = distinct_id, groups=groups)
+   sprinkle_clicks_on_page(distinct_id, '/', timestamp, client_properties, groups)
 
    timestamp = timestamp + timedelta(minutes=random.randint(1,10))
-   
-   capture_pageview(url=f'https://hogflix.net/signup', client_properties = client_properties, timestamp=timestamp, distinct_id = distinct_id, groups=groups)
-   
+
+   capture_pageview(url=f'https://hogflix.net/plans', client_properties = client_properties, timestamp=timestamp, distinct_id = distinct_id, groups=groups)
+   sprinkle_clicks_on_page(distinct_id, '/plans', timestamp, client_properties, groups)
+
    timestamp = timestamp + timedelta(minutes=random.randint(1,10))
-   
+
+   capture_pageview(url=f'https://hogflix.net/signup', client_properties = client_properties, timestamp=timestamp, distinct_id = distinct_id, groups=groups)
+   sprinkle_clicks_on_page(distinct_id, '/signup', timestamp, client_properties, groups)
+   maybe_emit_exception(distinct_id, timestamp, client_properties, groups)
+
+   timestamp = timestamp + timedelta(minutes=random.randint(1,10))
+
    selected_plans = random.sample(plans,2)
    previous_plan = selected_plans[0]
    new_plan = selected_plans[1]

--- a/scripts/seed_demo_data.py
+++ b/scripts/seed_demo_data.py
@@ -12,6 +12,12 @@ from dotenv import load_dotenv
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from scripts.seed_helpers.browser_context import make_session_properties
+from scripts.seed_helpers.growth import (
+    daily_user_count,
+    behavioral_profile,
+    events_per_session,
+    is_user_active_on_day,
+)
 
 # The PostHog Python SDK injects host-machine $os/$os_version into every event,
 # overriding caller-supplied values. Strip those keys from the SDK's system
@@ -126,12 +132,18 @@ movies_catalog = {
   6: {"title": "The Hedge Abides"}
 }
 
-def get_random_time():
-    random_seconds = random.randint(0,int(args.number_of_days) * 86400)
+def get_random_time(day_offset=None):
+    """Random timestamp. If day_offset is set, return a time within that day
+    (days_ago=day_offset). Otherwise scatter across the whole window."""
+    if day_offset is not None:
+        return datetime.now() - timedelta(days=day_offset, seconds=random.randint(0, 86400))
+    random_seconds = random.randint(0, int(args.number_of_days) * 86400)
+    return datetime.now() - timedelta(seconds=random_seconds)
 
-    random_timestamp = datetime.now() - timedelta(seconds = random_seconds)
 
-    return(random_timestamp)
+def _user_id_int(email):
+    """Stable positive int per email for behavioral_profile()."""
+    return abs(hash(email)) & 0x7FFFFFFF
 
 def capture_pageview(url, timestamp, client_properties, distinct_id, groups = {}):
    properties = {
@@ -191,8 +203,8 @@ def get_client_properties(user = None):
       }
    return properties
 
-def browse_and_watch_movie(number = 1):
-   fake_user = random.choice(fake_users)
+def browse_and_watch_movie(number = 1, user=None, day_offset=None):
+   fake_user = user or random.choice(fake_users)
    distinct_id = fake_user['email']
 
    posthog.group_identify('family', fake_user['family_id'], {
@@ -202,7 +214,7 @@ def browse_and_watch_movie(number = 1):
    groups = {'family': fake_user['family_id']}
 
    for i in range(random.randint(1, number)):
-        timestamp = get_random_time()
+        timestamp = get_random_time(day_offset=day_offset)
         client_properties = get_client_properties(user=fake_user)
         
         capture_event(event='user_logged_in', extra_properties=client_properties, timestamp=timestamp, distinct_id=distinct_id, groups=groups)
@@ -256,12 +268,11 @@ def browse_and_watch_movie(number = 1):
                groups=groups,
             )
 
-def anon_browse_homepage_and_plans():
+def anon_browse_homepage_and_plans(day_offset=None):
    client_properties = get_client_properties()
    distinct_id = fake.uuid4()
-   print(distinct_id)
 
-   timestamp = get_random_time()
+   timestamp = get_random_time(day_offset=day_offset)
 
    capture_pageview(url='https://hogflix.net/', client_properties = client_properties,timestamp=timestamp, distinct_id = distinct_id)
    
@@ -276,12 +287,11 @@ def anon_browse_homepage_and_plans():
    
    capture_pageview(url=f'https://hogflix.net/signup', client_properties = client_properties, timestamp=timestamp, distinct_id = distinct_id)
 
-def browse_plans_and_signup():
-   fake_user = random.choice(fake_users)
+def browse_plans_and_signup(user=None, day_offset=None):
+   fake_user = user or random.choice(fake_users)
    client_properties = get_client_properties(user=fake_user)
    distinct_id = fake_user['email']
-   timestamp = get_random_time()
-   print(distinct_id)
+   timestamp = get_random_time(day_offset=day_offset)
 
    posthog.group_identify('family', fake_user['family_id'], {
       'name': fake_user['last_name']
@@ -310,7 +320,6 @@ def browse_plans_and_signup():
                         "$set": {
                            "plan": new_plan
                         }}
-   print(client_properties)
    capture_event(event='plan_changed', extra_properties=client_properties, timestamp=timestamp, distinct_id=distinct_id, groups=groups)
 
    # Emit subscription intent and purchase for Revenue Analytics
@@ -334,9 +343,55 @@ def browse_plans_and_signup():
       'currency': 'USD',
    }, timestamp=timestamp, distinct_id=distinct_id, groups=groups)
 
-for i in range(int(args.number_of_iterations)):
-   print(args)
-   browse_and_watch_movie(number = 10)
-   anon_browse_homepage_and_plans()
-   browse_plans_and_signup()
-   posthog.flush()
+total_days = int(args.number_of_days)
+
+# Pre-assign a deterministic signup_days_ago per fake_user. Distribute across
+# the window so the growth curve has natural fuel: only old signups can be
+# active on early days; recent signups appear later.
+user_signups = {
+    u['email']: random.Random(u['email']).randint(0, max(1, total_days - 1))
+    for u in fake_users
+}
+
+# Track which users have already had a signup flow emitted (browse_plans_and_signup)
+signed_up_users = set()
+
+print(f"Generating events for {total_days} days, {len(fake_users)} potential users.")
+
+for days_ago in range(total_days, -1, -1):
+    target = daily_user_count(days_ago, total_days)
+    eligible = [
+        u for u in fake_users
+        if is_user_active_on_day(_user_id_int(u['email']), days_ago, user_signups[u['email']])
+    ]
+    if len(eligible) > target:
+        eligible = random.Random(days_ago).sample(eligible, target)
+
+    for user in eligible:
+        profile = behavioral_profile(_user_id_int(user['email']))
+
+        # First active day for this user => emit the signup flow once.
+        if user['email'] not in signed_up_users and user_signups[user['email']] == days_ago:
+            browse_plans_and_signup(user=user, day_offset=days_ago)
+            signed_up_users.add(user['email'])
+            continue
+
+        # Otherwise pick a flow shape based on profile.
+        if profile == 'power':
+            browse_and_watch_movie(number=4, user=user, day_offset=days_ago)
+        elif profile == 'casual':
+            browse_and_watch_movie(number=2, user=user, day_offset=days_ago)
+        elif profile == 'churned':
+            browse_and_watch_movie(number=1, user=user, day_offset=days_ago)
+        elif profile == 'bouncer':
+            # Bouncers also browse anonymously sometimes
+            if random.random() < 0.5:
+                anon_browse_homepage_and_plans(day_offset=days_ago)
+            else:
+                browse_and_watch_movie(number=1, user=user, day_offset=days_ago)
+
+    # A handful of pure-anonymous browse sessions per day (top-of-funnel noise).
+    for _ in range(max(1, target // 10)):
+        anon_browse_homepage_and_plans(day_offset=days_ago)
+
+    posthog.flush()

--- a/scripts/seed_demo_data.py
+++ b/scripts/seed_demo_data.py
@@ -37,6 +37,13 @@ from scripts.seed_helpers.identity_issues import (
     unstable_distinct_ids,
     flag_flip_pattern,
 )
+from scripts.seed_helpers.data_quality import (
+    apply_event_typo,
+    apply_property_typo,
+    maybe_jsonify_property,
+    date_format_drift,
+    plan_name_drift,
+)
 
 # The PostHog Python SDK injects host-machine $os/$os_version into every event,
 # overriding caller-supplied values. Strip those keys from the SDK's system
@@ -224,24 +231,24 @@ def capture_pageview(url, timestamp, client_properties, distinct_id, groups = {}
    
 # Convert and capture Amplitude data
 def capture_event(event, extra_properties, timestamp, distinct_id, groups = {}):
+  uid = _hash_seed(distinct_id)
+  # C4 data quality: event-name typo for ~1.5% of mapped events.
+  event = apply_event_typo(event, uid)
 
-  payload = {
-    "event": event,
-    "distinct_id": distinct_id,
-    "properties": {
-      "timestamp": timestamp,
-      **extra_properties
-    },
+  merged_props = {
     "timestamp": timestamp,
-    "groups": groups
+    **extra_properties,
   }
 
+  # C5 data quality: occasionally rename user_id -> userId/userID/userid.
+  merged_props = apply_property_typo(merged_props, uid)
+
   posthog.capture(
-    event=payload["event"],
-    distinct_id=payload["distinct_id"],
-    properties=payload["properties"],
-    timestamp=payload["timestamp"],
-    groups=payload["groups"]
+    event=event,
+    distinct_id=distinct_id,
+    properties=merged_props,
+    timestamp=timestamp,
+    groups=groups,
   )
 
 def get_client_properties(user = None):
@@ -254,6 +261,8 @@ def get_client_properties(user = None):
          "$session_id": session_id,
          "$active_feature_flags": ["action_mode_on"],
          "$feature/action_mode_on": True if user['is_adult'] == 'Yes' else False,
+         "user_id": user['email'],  # C5 source for property-name typo
+         "family_id": user['family_id'],
          "$set": {
             "email": user['email'],
             "is_adult": user['is_adult'],
@@ -444,10 +453,16 @@ def browse_plans_and_signup(user=None, day_offset=None):
 
    selected_plans = random.sample(plans,2)
    previous_plan = selected_plans[0]
-   new_plan = selected_plans[1]
+   new_plan_canonical = selected_plans[1]
+   # C3 plan name drift: 5-10% of users see Maximal/Maxi-Mal instead of Max-imal.
+   uid = _user_id_int(distinct_id)
+   new_plan = plan_name_drift(new_plan_canonical, uid)
+   # C6 date format drift: signup_date is sometimes Date, sometimes DateTime.
+   signup_date = date_format_drift(datetime.now() - timedelta(days=random.randint(1, 60)), uid)
    client_properties = { **client_properties,
                         "previous_plan": previous_plan,
                         "new_plan": new_plan,
+                        "signup_date": signup_date,
                         "$set": {
                            "plan": new_plan
                         }}
@@ -473,9 +488,18 @@ def browse_plans_and_signup(user=None, day_offset=None):
       'months': months,
       'price': int(round(price_dollars * 100)),
       'currency': 'USD',
+      # Structured 'address' property — C7 occasionally JSON-stringifies it.
+      'address': {
+         'city': fake.city(),
+         'country': fake.country_code(),
+         'zip': fake.postcode(),
+      },
    }
-   # A5 cost amplifier: double-fire subscription_purchased.
-   double_fire_purchase(posthog, distinct_id, 'subscription_purchased',
+   purchase_props = maybe_jsonify_property(purchase_props, 'address', uid, probability=0.05)
+   # A5 cost amplifier: double-fire subscription_purchased. Apply C4 event-typo
+   # before the double-fire so the typo'd variant also fires twice.
+   subscription_event_name = apply_event_typo('subscription_purchased', uid)
+   double_fire_purchase(posthog, distinct_id, subscription_event_name,
                         purchase_props, timestamp, groups=groups)
 
 total_days = int(args.number_of_days)

--- a/scripts/seed_helpers/__init__.py
+++ b/scripts/seed_helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Helpers for the Hogflix demo seed script. Each submodule encapsulates one category of seed-time logic."""

--- a/scripts/seed_helpers/autocapture.py
+++ b/scripts/seed_helpers/autocapture.py
@@ -1,13 +1,277 @@
-"""Synthesize $autocapture, $rageclick, and $dead_click events."""
+"""Synthesize $autocapture, $rageclick, and $dead_click events.
+
+These mimic the element chains PostHog's web SDK would emit on real Hogflix
+pages so the seed data has realistic click signal for autocapture-driven
+insights, heatmaps, and rageclick/dead-click detection.
+"""
+
+import random
 
 
-def synthesize_autocapture(distinct_id, page, timestamp, session_props):
-    raise NotImplementedError
+# Realistic-looking element chains per Hogflix page. Each entry is a list of
+# possible click targets; each target is itself a chain of elements (innermost
+# first), modeled after PostHog's real $elements payloads.
+#
+# Pages covered match what scripts/seed_demo_data.py actually emits pageviews
+# for: /, /plans, /signup, /movie/<id>. /movies, /checkout, /account are added
+# for forward compatibility with future seed flows.
+_PAGE_ELEMENT_CHAINS = {
+    "/": [
+        # Hero "Sign up free" CTA
+        [
+            {"tag_name": "button", "text": "Sign up free", "attr__class": "btn btn-primary hero__cta", "attr__data-attr": "hero-signup-cta", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "div", "attr__class": "hero__actions", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "section", "attr__class": "hero hero--home", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "main", "attr__class": "page page--home", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "body", "attr__class": "theme-dark", "nth_child": 2, "nth_of_type": 1},
+        ],
+        # "Browse movies" link
+        [
+            {"tag_name": "a", "text": "Browse movies", "attr__class": "btn btn-secondary", "attr__href": "/movies", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "div", "attr__class": "hero__actions", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "section", "attr__class": "hero hero--home", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "main", "attr__class": "page page--home", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "body", "attr__class": "theme-dark", "nth_child": 2, "nth_of_type": 1},
+        ],
+        # Top-nav "Plans" link
+        [
+            {"tag_name": "a", "text": "Plans", "attr__class": "nav__link", "attr__href": "/plans", "nth_child": 3, "nth_of_type": 3},
+            {"tag_name": "ul", "attr__class": "nav__list", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "nav", "attr__class": "site-nav", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "header", "attr__class": "site-header", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "body", "attr__class": "theme-dark", "nth_child": 2, "nth_of_type": 1},
+        ],
+    ],
+    "/movies": [
+        # Movie tile click
+        [
+            {"tag_name": "a", "text": "Hogfather", "attr__class": "movie-tile movie-tile--featured", "attr__href": "/movie/1", "attr__data-movie-id": "1", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "li", "attr__class": "movie-grid__item", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "ul", "attr__class": "movie-grid", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "main", "attr__class": "page page--movies", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "body", "attr__class": "theme-dark", "nth_child": 2, "nth_of_type": 1},
+        ],
+        # Genre filter dropdown
+        [
+            {"tag_name": "button", "text": "Genre: All", "attr__class": "filter-dropdown__trigger", "attr__data-attr": "filter-genre", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "div", "attr__class": "filter-dropdown filter-dropdown--genre", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "section", "attr__class": "movies__filters", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "main", "attr__class": "page page--movies", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "body", "attr__class": "theme-dark", "nth_child": 2, "nth_of_type": 1},
+        ],
+        # "Upgrade plan" upsell banner
+        [
+            {"tag_name": "button", "text": "Upgrade to watch", "attr__class": "btn btn-upgrade upsell__cta", "attr__data-attr": "movies-upsell", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "div", "attr__class": "upsell upsell--inline", "nth_child": 3, "nth_of_type": 2},
+            {"tag_name": "main", "attr__class": "page page--movies", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "body", "attr__class": "theme-dark", "nth_child": 2, "nth_of_type": 1},
+        ],
+    ],
+    "/movie": [
+        # Watch now (primary action)
+        [
+            {"tag_name": "button", "text": "Watch now", "attr__class": "btn btn-primary movie__watch", "attr__data-attr": "movie-watch-now", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "div", "attr__class": "movie__actions", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "section", "attr__class": "movie__hero", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "main", "attr__class": "page page--movie", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "body", "attr__class": "theme-dark", "nth_child": 2, "nth_of_type": 1},
+        ],
+        # Add to family list
+        [
+            {"tag_name": "button", "text": "Add to family list", "attr__class": "btn btn-secondary movie__add-family", "attr__data-attr": "movie-add-family", "nth_child": 2, "nth_of_type": 2},
+            {"tag_name": "div", "attr__class": "movie__actions", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "section", "attr__class": "movie__hero", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "main", "attr__class": "page page--movie", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "body", "attr__class": "theme-dark", "nth_child": 2, "nth_of_type": 1},
+        ],
+        # Rent
+        [
+            {"tag_name": "button", "text": "Rent $4.99", "attr__class": "btn btn-tertiary movie__rent", "attr__data-attr": "movie-rent", "nth_child": 3, "nth_of_type": 3},
+            {"tag_name": "div", "attr__class": "movie__actions", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "section", "attr__class": "movie__hero", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "main", "attr__class": "page page--movie", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "body", "attr__class": "theme-dark", "nth_child": 2, "nth_of_type": 1},
+        ],
+        # Buy
+        [
+            {"tag_name": "button", "text": "Buy $14.99", "attr__class": "btn btn-tertiary movie__buy", "attr__data-attr": "movie-buy", "nth_child": 4, "nth_of_type": 4},
+            {"tag_name": "div", "attr__class": "movie__actions", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "section", "attr__class": "movie__hero", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "main", "attr__class": "page page--movie", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "body", "attr__class": "theme-dark", "nth_child": 2, "nth_of_type": 1},
+        ],
+    ],
+    "/checkout": [
+        # Confirm purchase
+        [
+            {"tag_name": "button", "text": "Confirm purchase", "attr__class": "btn btn-primary checkout__confirm", "attr__data-attr": "checkout-confirm", "attr__type": "submit", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "form", "attr__class": "checkout__form", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "section", "attr__class": "checkout", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "main", "attr__class": "page page--checkout", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "body", "attr__class": "theme-dark", "nth_child": 2, "nth_of_type": 1},
+        ],
+        # Plan radio (Premium)
+        [
+            {"tag_name": "input", "attr__class": "plan-radio plan-radio--premium", "attr__type": "radio", "attr__name": "plan", "attr__value": "premium", "nth_child": 2, "nth_of_type": 2},
+            {"tag_name": "label", "text": "Premium $14.99/mo", "attr__class": "plan-radio__label", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "fieldset", "attr__class": "checkout__plans", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "form", "attr__class": "checkout__form", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "main", "attr__class": "page page--checkout", "nth_child": 2, "nth_of_type": 1},
+        ],
+    ],
+    "/account": [
+        # Cancel subscription
+        [
+            {"tag_name": "button", "text": "Cancel subscription", "attr__class": "btn btn-danger account__cancel", "attr__data-attr": "account-cancel", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "div", "attr__class": "account__danger-zone", "nth_child": 4, "nth_of_type": 1},
+            {"tag_name": "section", "attr__class": "account__settings", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "main", "attr__class": "page page--account", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "body", "attr__class": "theme-dark", "nth_child": 2, "nth_of_type": 1},
+        ],
+        # Save settings
+        [
+            {"tag_name": "button", "text": "Save changes", "attr__class": "btn btn-primary account__save", "attr__type": "submit", "nth_child": 3, "nth_of_type": 1},
+            {"tag_name": "form", "attr__class": "account__form", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "section", "attr__class": "account__settings", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "main", "attr__class": "page page--account", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "body", "attr__class": "theme-dark", "nth_child": 2, "nth_of_type": 1},
+        ],
+    ],
+    "/plans": [
+        # Standard plan card -> Subscribe
+        [
+            {"tag_name": "button", "text": "Subscribe", "attr__class": "btn btn-primary plan-card__cta", "attr__data-plan": "standard", "nth_child": 4, "nth_of_type": 1},
+            {"tag_name": "article", "attr__class": "plan-card plan-card--standard", "nth_child": 2, "nth_of_type": 2},
+            {"tag_name": "div", "attr__class": "plans__grid", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "main", "attr__class": "page page--plans", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "body", "attr__class": "theme-dark", "nth_child": 2, "nth_of_type": 1},
+        ],
+        # Premium plan card -> Subscribe
+        [
+            {"tag_name": "button", "text": "Subscribe", "attr__class": "btn btn-primary plan-card__cta", "attr__data-plan": "premium", "nth_child": 4, "nth_of_type": 1},
+            {"tag_name": "article", "attr__class": "plan-card plan-card--premium plan-card--featured", "nth_child": 3, "nth_of_type": 3},
+            {"tag_name": "div", "attr__class": "plans__grid", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "main", "attr__class": "page page--plans", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "body", "attr__class": "theme-dark", "nth_child": 2, "nth_of_type": 1},
+        ],
+        # Compare plans toggle
+        [
+            {"tag_name": "button", "text": "Compare plans", "attr__class": "btn btn-link plans__compare-toggle", "attr__data-attr": "plans-compare", "nth_child": 3, "nth_of_type": 1},
+            {"tag_name": "section", "attr__class": "plans__intro", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "main", "attr__class": "page page--plans", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "body", "attr__class": "theme-dark", "nth_child": 2, "nth_of_type": 1},
+        ],
+    ],
+    "/signup": [
+        # Email input
+        [
+            {"tag_name": "input", "attr__class": "form-input form-input--email", "attr__type": "email", "attr__name": "email", "attr__placeholder": "you@example.com", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "label", "text": "Email address", "attr__class": "form-field__label", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "form", "attr__class": "signup__form", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "main", "attr__class": "page page--signup", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "body", "attr__class": "theme-dark", "nth_child": 2, "nth_of_type": 1},
+        ],
+        # Continue button
+        [
+            {"tag_name": "button", "text": "Continue", "attr__class": "btn btn-primary signup__continue", "attr__type": "submit", "attr__data-attr": "signup-continue", "nth_child": 3, "nth_of_type": 1},
+            {"tag_name": "form", "attr__class": "signup__form", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "main", "attr__class": "page page--signup", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "body", "attr__class": "theme-dark", "nth_child": 2, "nth_of_type": 1},
+        ],
+        # Sign in link (already have an account)
+        [
+            {"tag_name": "a", "text": "Sign in", "attr__class": "signup__signin-link", "attr__href": "/login", "nth_child": 1, "nth_of_type": 1},
+            {"tag_name": "p", "attr__class": "signup__footer", "nth_child": 4, "nth_of_type": 1},
+            {"tag_name": "main", "attr__class": "page page--signup", "nth_child": 2, "nth_of_type": 1},
+            {"tag_name": "body", "attr__class": "theme-dark", "nth_child": 2, "nth_of_type": 1},
+        ],
+    ],
+}
 
 
-def synthesize_rageclick(distinct_id, page, timestamp, session_props):
-    raise NotImplementedError
+def _resolve_page_key(page: str) -> str:
+    """Map a real pathname to a key in _PAGE_ELEMENT_CHAINS.
+
+    Handles dynamic segments like /movie/<id> and /movie/<id>/watch by matching
+    on prefix. Falls back to homepage chains for unknown pages so we never
+    crash mid-seed.
+    """
+    if not page or page == "/":
+        return "/"
+    # Match longest known prefix first. Order matters: /movies before /movie.
+    for prefix in ("/checkout", "/account", "/plans", "/signup", "/movies", "/movie"):
+        if page == prefix or page.startswith(prefix + "/"):
+            return prefix
+    return "/"
 
 
-def synthesize_dead_click(distinct_id, page, timestamp, session_props):
-    raise NotImplementedError
+def _make_element_chain(page: str) -> list:
+    """Generate a realistic element chain for a click on a typical Hogflix page.
+
+    Returns a list of 3-5 element dicts ordered innermost-first (the clicked
+    element comes first, body comes last). One of several plausible chains for
+    the page is picked at random, so the seed produces varied $elements payloads
+    instead of a single repeated pattern.
+    """
+    key = _resolve_page_key(page)
+    chains = _PAGE_ELEMENT_CHAINS.get(key) or _PAGE_ELEMENT_CHAINS["/"]
+    # Shallow copy so callers can mutate without poisoning the catalog.
+    return [dict(el) for el in random.choice(chains)]
+
+
+def synthesize_autocapture(posthog_client, distinct_id, page, timestamp, session_props, groups=None):
+    """Emit a $autocapture event for a click on a typical Hogflix page element."""
+    elements = _make_element_chain(page)
+    posthog_client.capture(
+        distinct_id=distinct_id,
+        event="$autocapture",
+        properties={
+            **session_props,
+            "$current_url": f"https://hogflix.net{page}",
+            "$pathname": page,
+            "$event_type": "click",
+            "$elements": elements,
+            "$lib": "web",
+        },
+        timestamp=timestamp,
+        groups=groups or {},
+    )
+
+
+def synthesize_rageclick(posthog_client, distinct_id, page, timestamp, session_props, groups=None):
+    """Emit a $rageclick event (3+ rapid clicks on same element)."""
+    elements = _make_element_chain(page)
+    posthog_client.capture(
+        distinct_id=distinct_id,
+        event="$rageclick",
+        properties={
+            **session_props,
+            "$current_url": f"https://hogflix.net{page}",
+            "$pathname": page,
+            "$event_type": "click",
+            "$elements": elements,
+            "$click_count": random.randint(4, 6),
+            "$lib": "web",
+        },
+        timestamp=timestamp,
+        groups=groups or {},
+    )
+
+
+def synthesize_dead_click(posthog_client, distinct_id, page, timestamp, session_props, groups=None):
+    """Emit a $dead_click event (click with no DOM change)."""
+    elements = _make_element_chain(page)
+    posthog_client.capture(
+        distinct_id=distinct_id,
+        event="$dead_click",
+        properties={
+            **session_props,
+            "$current_url": f"https://hogflix.net{page}",
+            "$pathname": page,
+            "$event_type": "click",
+            "$elements": elements,
+            "$lib": "web",
+        },
+        timestamp=timestamp,
+        groups=groups or {},
+    )

--- a/scripts/seed_helpers/autocapture.py
+++ b/scripts/seed_helpers/autocapture.py
@@ -1,0 +1,13 @@
+"""Synthesize $autocapture, $rageclick, and $dead_click events."""
+
+
+def synthesize_autocapture(distinct_id, page, timestamp, session_props):
+    raise NotImplementedError
+
+
+def synthesize_rageclick(distinct_id, page, timestamp, session_props):
+    raise NotImplementedError
+
+
+def synthesize_dead_click(distinct_id, page, timestamp, session_props):
+    raise NotImplementedError

--- a/scripts/seed_helpers/browser_context.py
+++ b/scripts/seed_helpers/browser_context.py
@@ -1,0 +1,6 @@
+"""Generate browser-context properties for a synthesized session."""
+
+
+def make_session_properties(user_seed: int) -> dict:
+    """Returns dict of $os/$browser/$referrer/UTM/$current_url-style properties for one session."""
+    raise NotImplementedError  # populated in Phase 2

--- a/scripts/seed_helpers/cost_amplifiers.py
+++ b/scripts/seed_helpers/cost_amplifiers.py
@@ -1,0 +1,25 @@
+"""Apply cost-amplifier patterns: pageleave spam, groupidentify spam, flag eval flood, identify spam, double-fire, anonymous profile creation."""
+
+
+def spam_pageleave(*args, **kwargs):
+    raise NotImplementedError
+
+
+def spam_groupidentify(*args, **kwargs):
+    raise NotImplementedError
+
+
+def flag_eval_flood(*args, **kwargs):
+    raise NotImplementedError
+
+
+def identify_spam(*args, **kwargs):
+    raise NotImplementedError
+
+
+def double_fire_purchase(*args, **kwargs):
+    raise NotImplementedError
+
+
+def anonymous_profile_creation(*args, **kwargs):
+    raise NotImplementedError

--- a/scripts/seed_helpers/cost_amplifiers.py
+++ b/scripts/seed_helpers/cost_amplifiers.py
@@ -1,25 +1,85 @@
 """Apply cost-amplifier patterns: pageleave spam, groupidentify spam, flag eval flood, identify spam, double-fire, anonymous profile creation."""
 
-
-def spam_pageleave(*args, **kwargs):
-    raise NotImplementedError
-
-
-def spam_groupidentify(*args, **kwargs):
-    raise NotImplementedError
+import random
+from datetime import timedelta
 
 
-def flag_eval_flood(*args, **kwargs):
-    raise NotImplementedError
+def spam_pageleave(posthog_client, distinct_id, page, timestamp, session_props, count=3, groups=None):
+    """Emit `count` $pageleave events for one page visit (the bug: app fires it on every click in addition to the autocapture)."""
+    for i in range(count):
+        posthog_client.capture(
+            distinct_id=distinct_id,
+            event="$pageleave",
+            properties={**session_props, "$current_url": f"https://hogflix.net{page}", "$pathname": page, "$lib": "web"},
+            timestamp=timestamp + timedelta(seconds=i * 5),
+            groups=groups or {},
+        )
 
 
-def identify_spam(*args, **kwargs):
-    raise NotImplementedError
+def spam_groupidentify(posthog_client, distinct_id, group_type, group_key, group_props, timestamp):
+    """Emit a $groupidentify event. The bug is that this fires on every page load - orchestrator calls this before every event in a session, not once per session."""
+    posthog_client.group_identify(
+        group_type=group_type,
+        group_key=str(group_key),
+        properties=group_props,
+        distinct_id=distinct_id,
+        timestamp=timestamp,
+    )
 
 
-def double_fire_purchase(*args, **kwargs):
-    raise NotImplementedError
+def flag_eval_flood(posthog_client, distinct_id, flag_keys, timestamp, session_props, flood_count=8, groups=None):
+    """Emit `flood_count` $feature_flag_called events per flag, simulating a re-evaluation loop."""
+    for flag_key in flag_keys:
+        for i in range(flood_count):
+            posthog_client.capture(
+                distinct_id=distinct_id,
+                event="$feature_flag_called",
+                properties={
+                    **session_props,
+                    "$feature_flag": flag_key,
+                    "$feature_flag_response": "control" if i % 2 == 0 else "test",
+                    "$lib": "web",
+                },
+                timestamp=timestamp + timedelta(seconds=i * 3),
+                groups=groups or {},
+            )
 
 
-def anonymous_profile_creation(*args, **kwargs):
-    raise NotImplementedError
+def identify_spam(posthog_client, distinct_id, timestamp, properties_to_set, count=5):
+    """Emit `count` $identify events for the same user — bug: app calls identify() on every page load.
+
+    PostHog Python SDK 7.x has no top-level identify(); $identify is sent as a
+    regular capture() call with $set in properties.
+    """
+    for i in range(count):
+        posthog_client.capture(
+            distinct_id=distinct_id,
+            event="$identify",
+            properties={"$set": properties_to_set, "$lib": "web"},
+            timestamp=timestamp + timedelta(seconds=i * 30),
+        )
+
+
+def double_fire_purchase(posthog_client, distinct_id, event_name, properties, timestamp, groups=None):
+    """Emit the same purchase event twice within a few seconds."""
+    posthog_client.capture(distinct_id=distinct_id, event=event_name, properties=properties, timestamp=timestamp, groups=groups or {})
+    posthog_client.capture(distinct_id=distinct_id, event=event_name, properties=properties, timestamp=timestamp + timedelta(seconds=2), groups=groups or {})
+
+
+def anonymous_profile_creation(posthog_client, distinct_id, timestamp, session_props):
+    """Emit an $identify event for an anonymous distinct_id (no real user) so a person profile is created.
+    Effect of person_profiles='always' on a real customer's instance: every anonymous browse session creates a billed person profile.
+
+    PostHog Python SDK 7.x has no top-level identify(); $identify is sent as a
+    regular capture() with $set in properties.
+    """
+    posthog_client.capture(
+        distinct_id=distinct_id,
+        event="$identify",
+        properties={
+            "$set": {"session_started_at": timestamp.isoformat()},
+            **session_props,
+            "$lib": "web",
+        },
+        timestamp=timestamp,
+    )

--- a/scripts/seed_helpers/data_quality.py
+++ b/scripts/seed_helpers/data_quality.py
@@ -1,0 +1,21 @@
+"""Intentional data quality variants: typos, JSON-stringified values, format drift."""
+
+
+def apply_event_typo(event_name):
+    raise NotImplementedError
+
+
+def apply_property_typo(props):
+    raise NotImplementedError
+
+
+def jsonify_property(props, key):
+    raise NotImplementedError
+
+
+def date_format_drift(date_value):
+    raise NotImplementedError
+
+
+def plan_name_drift(plan_name):
+    raise NotImplementedError

--- a/scripts/seed_helpers/data_quality.py
+++ b/scripts/seed_helpers/data_quality.py
@@ -1,21 +1,66 @@
 """Intentional data quality variants: typos, JSON-stringified values, format drift."""
+import json
+import random
+
+EVENT_TYPO_MAP = {
+    "subscription_purchased": "suscription_purchased",  # 'b' missing
+    "movie_buy_complete": "movei_buy_complete",  # transposed letters
+    "user_logged_in": "user_loged_in",  # 'g' missing
+}
 
 
-def apply_event_typo(event_name):
-    raise NotImplementedError
+def apply_event_typo(event_name: str, user_id: int) -> str:
+    """For ~1-2% of events deterministically, return a typo'd variant. Otherwise return the original."""
+    rng = random.Random(f"{event_name}:{user_id}")
+    if event_name in EVENT_TYPO_MAP and rng.random() < 0.015:
+        return EVENT_TYPO_MAP[event_name]
+    return event_name
 
 
-def apply_property_typo(props):
-    raise NotImplementedError
+def apply_property_typo(props: dict, user_id: int) -> dict:
+    """Inconsistent property naming for the same concept across events.
+    Examples: user_id vs userId vs userID, family_id vs familyId.
+    For 1-2% of events, swap the canonical key with a variant.
+    """
+    typo_map = {"user_id": ["userId", "userID", "userid"]}
+    new_props = dict(props)
+    rng = random.Random(f"props:{user_id}")
+    for canonical, variants in typo_map.items():
+        if canonical in new_props and rng.random() < 0.015:
+            variant = rng.choice(variants)
+            new_props[variant] = new_props.pop(canonical)
+    return new_props
 
 
-def jsonify_property(props, key):
-    raise NotImplementedError
+def maybe_jsonify_property(props: dict, key: str, user_id: int, probability=0.05) -> dict:
+    """For ~5% of events with the given key, replace the value with a JSON-stringified version (the bug: customer is sending an object as a JSON string instead of a structured property)."""
+    rng = random.Random(f"json:{key}:{user_id}")
+    if key in props and rng.random() < probability:
+        new_props = dict(props)
+        if isinstance(props[key], (dict, list)):
+            new_props[key] = json.dumps(props[key])
+        else:
+            new_props[key] = json.dumps({"value": props[key], "type": type(props[key]).__name__})
+        return new_props
+    return props
 
 
-def date_format_drift(date_value):
-    raise NotImplementedError
+def date_format_drift(date_value, user_id: int):
+    """Sometimes return ISO Date, sometimes ISO DateTime, for the same field across events."""
+    rng = random.Random(f"date:{user_id}")
+    if rng.random() < 0.4:
+        return date_value.date().isoformat()
+    return date_value.isoformat()
 
 
-def plan_name_drift(plan_name):
-    raise NotImplementedError
+def plan_name_drift(plan_name: str, user_id: int) -> str:
+    """For 5-10% of plan-related events, use 'Maximal' (no hyphen) or 'Maxi-Mal' (alternate hyphenation) instead of 'Max-imal'."""
+    if plan_name != "Max-imal":
+        return plan_name
+    rng = random.Random(f"plan:{user_id}")
+    r = rng.random()
+    if r < 0.07:
+        return "Maximal"
+    if r < 0.10:
+        return "Maxi-Mal"
+    return "Max-imal"

--- a/scripts/seed_helpers/exceptions.py
+++ b/scripts/seed_helpers/exceptions.py
@@ -1,0 +1,5 @@
+"""Synthesize $exception events."""
+
+
+def synthesize_exception(distinct_id, timestamp, session_props):
+    raise NotImplementedError

--- a/scripts/seed_helpers/exceptions.py
+++ b/scripts/seed_helpers/exceptions.py
@@ -1,5 +1,272 @@
 """Synthesize $exception events."""
 
+import random
 
-def synthesize_exception(distinct_id, timestamp, session_props):
-    raise NotImplementedError
+EXCEPTION_TEMPLATES = [
+    {
+        "$exception_type": "TypeError",
+        "$exception_message": "Cannot read property 'price' of undefined",
+        "$exception_list": [
+            {
+                "type": "TypeError",
+                "value": "Cannot read property 'price' of undefined",
+                "stacktrace": {
+                    "type": "raw",
+                    "frames": [
+                        {
+                            "filename": "https://hogflix.net/static/js/checkout.js",
+                            "lineno": 142,
+                            "colno": 18,
+                            "function": "computePrice",
+                        },
+                        {
+                            "filename": "https://hogflix.net/static/js/checkout.js",
+                            "lineno": 88,
+                            "colno": 5,
+                            "function": "renderCheckout",
+                        },
+                    ],
+                },
+            }
+        ],
+    },
+    {
+        "$exception_type": "TypeError",
+        "$exception_message": "Cannot read property 'plan' of null",
+        "$exception_list": [
+            {
+                "type": "TypeError",
+                "value": "Cannot read property 'plan' of null",
+                "stacktrace": {
+                    "type": "raw",
+                    "frames": [
+                        {
+                            "filename": "https://hogflix.net/static/js/account.js",
+                            "lineno": 88,
+                            "colno": 12,
+                            "function": "renderAccountPlan",
+                        },
+                        {
+                            "filename": "https://hogflix.net/static/js/account.js",
+                            "lineno": 21,
+                            "colno": 3,
+                            "function": "initAccount",
+                        },
+                    ],
+                },
+            }
+        ],
+    },
+    {
+        "$exception_type": "ReferenceError",
+        "$exception_message": "posthog is not defined",
+        "$exception_list": [
+            {
+                "type": "ReferenceError",
+                "value": "posthog is not defined",
+                "stacktrace": {
+                    "type": "raw",
+                    "frames": [
+                        {
+                            "filename": "https://hogflix.net/static/js/analytics.js",
+                            "lineno": 5,
+                            "colno": 1,
+                            "function": "trackPageview",
+                        },
+                    ],
+                },
+            }
+        ],
+    },
+    {
+        "$exception_type": "SyntaxError",
+        "$exception_message": "Unexpected token < in JSON at position 0",
+        "$exception_list": [
+            {
+                "type": "SyntaxError",
+                "value": "Unexpected token < in JSON at position 0",
+                "stacktrace": {
+                    "type": "raw",
+                    "frames": [
+                        {
+                            "filename": "https://hogflix.net/static/js/api.js",
+                            "lineno": 201,
+                            "colno": 22,
+                            "function": "parseResponse",
+                        },
+                        {
+                            "filename": "https://hogflix.net/static/js/api.js",
+                            "lineno": 174,
+                            "colno": 9,
+                            "function": "fetchJson",
+                        },
+                    ],
+                },
+            }
+        ],
+    },
+    {
+        "$exception_type": "TypeError",
+        "$exception_message": "Failed to fetch",
+        "$exception_list": [
+            {
+                "type": "TypeError",
+                "value": "Failed to fetch",
+                "stacktrace": {
+                    "type": "raw",
+                    "frames": [
+                        {
+                            "filename": "https://hogflix.net/static/js/movie-detail.js",
+                            "lineno": 67,
+                            "colno": 14,
+                            "function": "loadMovieDetail",
+                        },
+                    ],
+                },
+            }
+        ],
+    },
+    {
+        "$exception_type": "RangeError",
+        "$exception_message": "Maximum call stack size exceeded",
+        "$exception_list": [
+            {
+                "type": "RangeError",
+                "value": "Maximum call stack size exceeded",
+                "stacktrace": {
+                    "type": "raw",
+                    "frames": [
+                        {
+                            "filename": "https://hogflix.net/static/js/recursive-render.js",
+                            "lineno": 23,
+                            "colno": 7,
+                            "function": "renderTree",
+                        },
+                        {
+                            "filename": "https://hogflix.net/static/js/recursive-render.js",
+                            "lineno": 23,
+                            "colno": 7,
+                            "function": "renderTree",
+                        },
+                    ],
+                },
+            }
+        ],
+    },
+    {
+        "$exception_type": "Error",
+        "$exception_message": "Network request failed",
+        "$exception_list": [
+            {
+                "type": "Error",
+                "value": "Network request failed",
+                "stacktrace": {
+                    "type": "raw",
+                    "frames": [
+                        {
+                            "filename": "https://hogflix.net/static/js/checkout.js",
+                            "lineno": 189,
+                            "colno": 11,
+                            "function": "submitOrder",
+                        },
+                    ],
+                },
+            }
+        ],
+    },
+    {
+        "$exception_type": "TypeError",
+        "$exception_message": "Cannot set property 'innerHTML' of null",
+        "$exception_list": [
+            {
+                "type": "TypeError",
+                "value": "Cannot set property 'innerHTML' of null",
+                "stacktrace": {
+                    "type": "raw",
+                    "frames": [
+                        {
+                            "filename": "https://hogflix.net/static/js/homepage.js",
+                            "lineno": 42,
+                            "colno": 9,
+                            "function": "renderHero",
+                        },
+                    ],
+                },
+            }
+        ],
+    },
+    {
+        "$exception_type": "TypeError",
+        "$exception_message": "video.play is not a function",
+        "$exception_list": [
+            {
+                "type": "TypeError",
+                "value": "video.play is not a function",
+                "stacktrace": {
+                    "type": "raw",
+                    "frames": [
+                        {
+                            "filename": "https://hogflix.net/static/js/player.js",
+                            "lineno": 117,
+                            "colno": 16,
+                            "function": "startPlayback",
+                        },
+                        {
+                            "filename": "https://hogflix.net/static/js/player.js",
+                            "lineno": 54,
+                            "colno": 4,
+                            "function": "initPlayer",
+                        },
+                    ],
+                },
+            }
+        ],
+    },
+    {
+        "$exception_type": "Error",
+        "$exception_message": "Unauthorized",
+        "$exception_list": [
+            {
+                "type": "Error",
+                "value": "Unauthorized",
+                "stacktrace": {
+                    "type": "raw",
+                    "frames": [
+                        {
+                            "filename": "https://hogflix.net/static/js/auth.js",
+                            "lineno": 55,
+                            "colno": 13,
+                            "function": "refreshToken",
+                        },
+                    ],
+                },
+            }
+        ],
+    },
+]
+
+
+def synthesize_exception(posthog_client, distinct_id, timestamp, session_props, groups=None, template_idx=None):
+    """Emit a single $exception event using one of the predefined templates.
+
+    Args:
+        posthog_client: A PostHog client with a `.capture(...)` method.
+        distinct_id: The distinct_id to attribute the event to.
+        timestamp: The event timestamp (datetime).
+        session_props: Base session properties merged into the event (e.g. $current_url, $session_id).
+        groups: Optional groups dict passed through to capture().
+        template_idx: Optional index into EXCEPTION_TEMPLATES; random if None.
+    """
+    idx = template_idx if template_idx is not None else random.randint(0, len(EXCEPTION_TEMPLATES) - 1)
+    template = EXCEPTION_TEMPLATES[idx]
+    posthog_client.capture(
+        distinct_id=distinct_id,
+        event="$exception",
+        properties={
+            **session_props,
+            **template,
+            "$lib": "web",
+        },
+        timestamp=timestamp,
+        groups=groups or {},
+    )

--- a/scripts/seed_helpers/growth.py
+++ b/scripts/seed_helpers/growth.py
@@ -1,0 +1,11 @@
+"""Growth curve and behavioral cohort distribution."""
+
+
+def daily_user_count(days_ago: int) -> int:
+    """Returns the number of active users for a day N days in the past."""
+    raise NotImplementedError  # populated in Phase 3
+
+
+def behavioral_profile(user_id: int) -> str:
+    """Returns 'power' | 'casual' | 'churned' | 'bouncer' deterministically per user_id."""
+    raise NotImplementedError  # populated in Phase 3

--- a/scripts/seed_helpers/growth.py
+++ b/scripts/seed_helpers/growth.py
@@ -1,11 +1,66 @@
 """Growth curve and behavioral cohort distribution."""
 
+from datetime import datetime, timedelta
+import random
 
-def daily_user_count(days_ago: int) -> int:
-    """Returns the number of active users for a day N days in the past."""
-    raise NotImplementedError  # populated in Phase 3
+SEED = 42
+
+
+def daily_user_count(days_ago: int, total_days: int = 120) -> int:
+    """Number of active users (with at least one event) on the day N days ago.
+
+    Growth curve from 50 active users at the start of the data window (days_ago=120)
+    to 250 at the end (days_ago=0). Weekday baseline; weekends bumped 1.4x.
+    """
+    progress = (total_days - days_ago) / total_days
+    base = 50 + (200 * progress)
+    weekday = (datetime.now() - timedelta(days=days_ago)).weekday()
+    weekend_factor = 1.4 if weekday >= 5 else 1.0
+    return int(base * weekend_factor)
 
 
 def behavioral_profile(user_id: int) -> str:
-    """Returns 'power' | 'casual' | 'churned' | 'bouncer' deterministically per user_id."""
-    raise NotImplementedError  # populated in Phase 3
+    """Deterministic mapping of user_id to one of: power, casual, churned, bouncer."""
+    rng = random.Random(user_id)
+    r = rng.random()
+    if r < 0.05:
+        return "power"
+    if r < 0.80:
+        return "casual"  # 0.05 + 0.75
+    if r < 0.95:
+        return "churned"  # +0.15
+    return "bouncer"  # remaining 0.05
+
+
+def events_per_session(profile: str) -> int:
+    """How many events one session produces, by behavior cohort."""
+    return {
+        "power": random.randint(20, 50),
+        "casual": random.randint(3, 15),
+        "churned": random.randint(2, 10),
+        "bouncer": random.randint(1, 3),
+    }[profile]
+
+
+def is_user_active_on_day(user_id: int, days_ago: int, signup_days_ago: int) -> bool:
+    """Determines whether a user is active on a given day based on profile + tenure.
+
+    - power: active most days after signup
+    - casual: active on ~30% of days after signup
+    - churned: active for first 60 days after signup, then never
+    - bouncer: active for first 1-3 days after signup, then never
+    """
+    if days_ago > signup_days_ago:
+        return False  # hasn't signed up yet
+    days_since_signup = signup_days_ago - days_ago
+    profile = behavioral_profile(user_id)
+    rng = random.Random(user_id * 1000 + days_ago)
+    if profile == "power":
+        return rng.random() < 0.7
+    if profile == "casual":
+        return rng.random() < 0.3
+    if profile == "churned":
+        return days_since_signup <= 60 and rng.random() < 0.4
+    if profile == "bouncer":
+        return days_since_signup <= rng.randint(1, 3)
+    return False

--- a/scripts/seed_helpers/identity_issues.py
+++ b/scripts/seed_helpers/identity_issues.py
@@ -1,13 +1,105 @@
 """Identity instability patterns."""
 
-
-def unstable_distinct_ids(*args, **kwargs):
-    raise NotImplementedError
-
-
-def flag_flip_pattern(*args, **kwargs):
-    raise NotImplementedError
+import random
+from datetime import timedelta
 
 
-def maybe_identify_user(*args, **kwargs):
-    raise NotImplementedError
+def _user_id_int(user):
+    """Stable positive int seed from a user dict (uses 'email' field)."""
+    return abs(hash(user.get('email', ''))) & 0x7FFFFFFF
+
+
+def maybe_identify_user(posthog_client, user, distinct_id, timestamp, session_props, probability=0.10, groups=None):
+    """For ~10% of users, emit a $identify-shaped event so they become identified.
+    Returns True if identified.
+
+    PostHog Python SDK 7.x: identify is sent as capture('$identify', ..., $set=...).
+    """
+    rng = random.Random(_user_id_int(user))
+    if rng.random() < probability:
+        posthog_client.capture(
+            distinct_id=distinct_id,
+            event="$identify",
+            properties={
+                "$set": {
+                    'email': user.get('email'),
+                    'plan': user.get('plan'),
+                    'is_adult': user.get('is_adult'),
+                },
+                **session_props,
+                "$lib": "web",
+            },
+            timestamp=timestamp,
+            groups=groups or {},
+        )
+        return True
+    return False
+
+
+def unstable_distinct_ids(user, base_distinct_id):
+    """For ~5% of users, simulate distinct_id instability: their session uses one ID,
+    then unexpectedly switches to a different ID without an alias call.
+
+    Returns a list of distinct_ids; caller picks one randomly per event so the same
+    user appears under 2-3 different IDs across their events. For the other 95%, returns [base_distinct_id].
+    """
+    rng = random.Random(_user_id_int(user) * 17)
+    if rng.random() >= 0.05:
+        return [base_distinct_id]
+    n_alts = rng.randint(1, 2)
+    return [base_distinct_id] + [f"{base_distinct_id}-alt-{i}" for i in range(n_alts)]
+
+
+def flag_flip_pattern(posthog_client, user, distinct_id, timestamp, session_props, flag_name="action_mode_on", groups=None):
+    """For ~5% of users, emit events with conflicting `$feature/<flag>` values pre and post identify.
+
+    Pre-identify: anonymous, flag = "control".
+    Post-identify: identified, flag = "test".
+    """
+    rng = random.Random(_user_id_int(user) * 31)
+    if rng.random() >= 0.05:
+        return
+
+    # Pre-identify event
+    posthog_client.capture(
+        distinct_id=distinct_id,
+        event="$pageview",
+        properties={
+            **session_props,
+            f"$feature/{flag_name}": "control",
+            "$active_feature_flags": [flag_name],
+            "$lib": "web",
+        },
+        timestamp=timestamp,
+        groups=groups or {},
+    )
+
+    # Identify call (via capture)
+    posthog_client.capture(
+        distinct_id=distinct_id,
+        event="$identify",
+        properties={
+            "$set": {
+                'email': user.get('email'),
+                'plan': user.get('plan'),
+            },
+            **session_props,
+            "$lib": "web",
+        },
+        timestamp=timestamp + timedelta(minutes=2),
+        groups=groups or {},
+    )
+
+    # Post-identify event with flipped flag
+    posthog_client.capture(
+        distinct_id=distinct_id,
+        event="$pageview",
+        properties={
+            **session_props,
+            f"$feature/{flag_name}": "test",
+            "$active_feature_flags": [flag_name],
+            "$lib": "web",
+        },
+        timestamp=timestamp + timedelta(minutes=3),
+        groups=groups or {},
+    )

--- a/scripts/seed_helpers/identity_issues.py
+++ b/scripts/seed_helpers/identity_issues.py
@@ -1,0 +1,13 @@
+"""Identity instability patterns."""
+
+
+def unstable_distinct_ids(*args, **kwargs):
+    raise NotImplementedError
+
+
+def flag_flip_pattern(*args, **kwargs):
+    raise NotImplementedError
+
+
+def maybe_identify_user(*args, **kwargs):
+    raise NotImplementedError

--- a/scripts/seed_helpers/profiles.py
+++ b/scripts/seed_helpers/profiles.py
@@ -1,0 +1,15 @@
+"""Realistic device and referrer profiles for synthesized sessions."""
+
+# DEVICE_PROFILES: list of dicts with $os, $os_version, $browser, $browser_version,
+# $device_type, $screen_width, $screen_height (10-12 entries spanning
+# Windows/Mac/iOS/Android, Chrome/Safari/Firefox/Edge/Mobile Safari)
+DEVICE_PROFILES = []  # populated in Phase 2
+
+# REFERRER_PROFILES: list of dicts with $referrer, $referring_domain,
+# optional utm_source/medium/campaign (10-15 entries: Google organic, Twitter social,
+# Product Hunt, $direct, etc.)
+REFERRER_PROFILES = []  # populated in Phase 2
+
+# USER_BEHAVIOR_COHORTS: dict mapping cohort name to weight,
+# e.g. {"power": 0.05, "casual": 0.75, "churned": 0.15, "bouncer": 0.05}
+USER_BEHAVIOR_COHORTS = {}  # populated in Phase 3


### PR DESCRIPTION
I was playing around with Hogflix for the purposes of Superdays, but when I tested it, it lacked quite a few events that could be useful for inspecting the data for optimizations, building out dashboards with more historical data, etc.

So I attempted to fix that with Claude Code and tested it on this project: https://us.posthog.com/project/393153/dashboard/1550373 - everything seems to work well.

I know it's a massive PR, and I'm not a dev so there are possibly bad things here, but I'd love for someone to take a look! Asking @andrewm4894 because you seem to have been the active person in this repo. Thanks! 


## Summary

Bumps `make seed` from a thin server-side dataset (30 days, ~465 persons, ~3k events) to a richer, more realistic substrate (120 days of growth-curve data, thousands of persons across 4 behavior cohorts, hundreds of thousands of events, full PostHog product surface coverage).

The goal: make a freshly-seeded Hogflix instance look like a real customer's PostHog project — realistic browser/OS variety, growth and retention shape, autocapture/exception/rage-click events, and a full set of pre-built artifacts (surveys, experiments, more flags, cohorts, insights, dashboards).

## What changed

### New module: `scripts/seed_helpers/`
- `profiles.py` — 11 device profiles (Win/Mac/iOS/Android/Linux × Chrome/Safari/Firefox/Edge/Mobile Safari/Samsung Internet) and 13 referrer/UTM combos.
- `browser_context.py` — `make_session_properties()` overrides `$os`/`$browser`/UTM per session. The PostHog Python SDK injects host-machine `$os`/`$os_version` after caller properties; we monkey-patch `posthog.client.system_context` to drop those keys so per-session profiles win.
- `growth.py` — daily user count climbs 50→250 across the window with a 1.4× weekend bump; 4 behavior cohorts (power 5%, casual 75%, churned 15%, bouncer 5%).
- `autocapture.py` — synthesizes `$autocapture`, `$rageclick`, `$dead_click` with realistic 5-deep `$elements` chains for `/`, `/movies`, `/movie/<id>`, `/checkout`, `/account`, `/plans`, `/signup`.
- `exceptions.py` — 10 `$exception` templates with raw stacktraces (TypeError / ReferenceError / SyntaxError / RangeError / Error).
- `cost_amplifiers.py` — `spam_pageleave`, `spam_groupidentify`, `flag_eval_flood`, `identify_spam`, `double_fire_purchase`, `anonymous_profile_creation`. PostHog Python SDK 7.x has no top-level `identify()`, so all `$identify` flows are sent as `capture("$identify", ..., $set=...)`.
- `identity_issues.py` — `maybe_identify_user`, `unstable_distinct_ids`, `flag_flip_pattern`.
- `data_quality.py` — event-name typos (~1.5%), property-name inconsistency (`user_id` ↔ `userId`/`userID`/`userid`, ~1.5%), `maybe_jsonify_property` (~5% turn an object into a JSON string), `date_format_drift` (40% Date / 60% DateTime), `plan_name_drift` (`Max-imal` → 7% `Maximal` / 3% `Maxi-Mal`).

### `scripts/seed_demo_data.py`
- Iterates 120 days backward with `is_user_active_on_day` + `behavioral_profile`. Each user gets a deterministic `signup_days_ago`; the first active day emits `browse_plans_and_signup`; subsequent days pick a session flow based on profile.
- Browser context injected on every event (replaces the old 8-element `device_properties` list).
- `capture_event` applies event/property typos for every event.
- `subscription_purchased` runs through `apply_event_typo` then `double_fire_purchase`. Adds a structured `address` property; `maybe_jsonify_property` occasionally stringifies it.
- All session flows accept `user` and `day_offset` kwargs so the day-walker drives them.

### `scripts/create_posthog_artifacts.py`
- New `precheck_scopes()` fails fast with named missing scopes (the script was previously swallowing 403s).
- Six new idempotent creation functions: `create_surveys`, `create_more_feature_flags`, `create_experiment`, `create_more_cohorts`, `create_more_insights`, `create_dashboards`.
- Each function checks for an existing artifact by name (or flag key) and skips if found, so re-running against the same project doesn't duplicate.

### Configuration
- `Makefile`: bump default DAYS=120, ITER=300.
- `README.md`: document the 8 required Personal API key scopes upfront.

## New artifacts created

- 2 surveys (Post-purchase NPS, Why did you cancel?)
- 1 experiment (Free trial length: 7 days vs 14 days)
- 3 new feature flags (`payment_flow_v2` 100%, `premium_trial_banner` 0%, `churn_risk_targeting` with property targeting) plus `action_mode_on` (existing)
- 4 new cohorts (Power users, Trial bouncers, High-value subscribers, Defined but unused)
- 10 new insights covering trends, funnels, retention, lifecycle, stickiness, plus two SQL insights (one intentionally uses `value` instead of `price` to demonstrate the revenue-field divergence)
- 2 dashboards (Customer health, Revenue) with insight tiles attached

## Volume comparison (before → after, single test project run)

| Metric | Before | After |
|---|---|---|
| Days of data | 30 (most events in last 3 days) | 120 (evenly distributed) |
| Distinct event types | 10 | 14+ (added `$exception`, `$autocapture`, `$rageclick`, `$dead_click`, `$identify`) |
| Pre-built insights | 2 | 10 new (one with broken-on-purpose SQL revenue, one referencing a missing action) |
| Pre-built feature flags | 0 (silent fail) | 4 |
| Pre-built surveys | 0 | 2 |
| Pre-built experiments | 0 | 1 |
| Pre-built cohorts | 1 | 4 new |
| Pre-built dashboards | 1 | 2 new |

## Required scopes

The script now fails fast if the Personal API key lacks any of these:
- `action:write`, `cohort:write`, `dashboard:write`, `experiment:write`
- `feature_flag:write`, `insight:write`, `query:read`, `survey:write`

See README for setup steps.

## Verified locally

Tested by running `make seed` (DAYS=120 ITER=300) and `make artifacts` against PostHog project `393153`. Verified the expected event types, ratios, and artifacts via SQL queries. Spot checks:

- `$pageleave` / `$pageview` ratio ≈ 2.6× (intentional pageleave spam)
- `$groupidentify` ≈ `$pageview` (intentional groupidentify spam)
- `$exception` events span 5 distinct types
- Plan name drift: `Max-imal` (90%), `Maximal` (4.5%), `Maxi-Mal` (0.7%)
- Property typos: `user_id` (256k) plus `userId` / `userID` / `userid` variants
- 30+ identified users have multiple `distinct_id`s (identity instability)
- All 4 new feature flags + 10 new insights + 2 dashboards present in the test project

## Why this matters

A fresh-cloned Hogflix today produces a PostHog project a customer would describe as "barely set up" — heavy server-side, almost no product surface, flat data, mostly-empty UI. This PR makes it look like a customer who has been actively using PostHog for 4 months: rich data across product surfaces, the realistic mix of working features and instrumentation gaps that real customers run into.

## Draft for review

Marking as draft until the demo/devrel team has had a chance to review the approach. Ready to merge once approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)