### PR TITLE
fix: use keyword args for posthog.capture distinct_id

### DIFF
--- a/app.py
+++ b/app.py
@@ -115,9 +115,10 @@ def signup():
             db.session.add(user)
             db.session.commit()
             app.logger.debug(f"New user created: {user.username} with plan: {user.plan}")
-            posthog.capture(form.email.data, 
-                event='user_signed_up', 
-                properties = {
+            posthog.capture(
+                event='user_signed_up',
+                distinct_id=form.email.data,
+                properties={
                     'plan': plan,
                     'date_time': formatted_time
                 }
@@ -126,8 +127,9 @@ def signup():
             try:
                 months = 1
                 price_dollars = PLAN_PRICES.get(plan, 0)
-                posthog.capture(form.email.data,
+                posthog.capture(
                     event='subscription_purchased',
+                    distinct_id=form.email.data,
                     properties={
                         'plan': plan,
                         'months': months,
@@ -177,8 +179,8 @@ def login():
 def logout():
     if current_user.is_authenticated:
         posthog.capture(
-            current_user.email,         # Required - your user's ID
-            event='user_logged_out',    # Required - name of the event       
+            event='user_logged_out',    # Required - name of the event
+            distinct_id=current_user.email,  # The user's ID
             properties={
                 'date_time': formatted_time
             }
@@ -193,7 +195,7 @@ def logout():
 @csrf.exempt  # Disable CSRF for this route for debugging. 
 def search():
     query = request.form.get('query')
-    posthog.capture('search', 'search_performed', {'query': query})
+    posthog.capture(event='search_performed', distinct_id='search', properties={'query': query})
     return redirect(url_for('search_results', query=query))
 
 @app.route('/search_results')
@@ -391,8 +393,8 @@ def chat_api():
         # Capture a basic generation event for visibility even without wrapper
         try:
             posthog.capture(
-                distinct_id,
                 event='$ai_generation',
+                distinct_id=distinct_id,
                 properties={
                     '$ai_model': 'gpt-4o-mini',
                     '$ai_provider': 'openai',


### PR DESCRIPTION
## Summary

Signing up (and several other actions) crashed with:

```
TypeError: Client.capture() got multiple values for argument 'event'
```

The PostHog Python SDK's `capture()` signature is now `capture(event, **kwargs)` — `event` is the first positional argument and `distinct_id` is a keyword. The app was passing the distinct_id positionally while also passing `event=...`, so both mapped to `event` and collided.

This PR passes `distinct_id` as a keyword argument at every `posthog.capture()` call site in `app.py`:

- `user_signed_up` (signup)
- `subscription_purchased` (signup)
- `user_logged_out` (logout)
- `search_performed` (search) — also fixed properties being passed positionally
- `$ai_generation` (chat)

`scripts/seed_demo_data.py` already used the keyword form and was left unchanged.

## Test plan

- [x] Sign up a new user with each plan (Free / Premium / Max-imal) and confirm no `TypeError` and events arrive in PostHog
- [x] Log out and confirm `user_logged_out` is captured
- [x] Run a search and confirm `search_performed` is captured
- [x] Trigger a chat generation and confirm `$ai_generation` is captured

Made with [Cursor](https://cursor.com)