### PR TITLE
fix: migrate posthog.capture() calls to SDK v7 signature

### DIFF
--- a/app.py
+++ b/app.py
@@ -115,8 +115,9 @@ def signup():
             db.session.add(user)
             db.session.commit()
             app.logger.debug(f"New user created: {user.username} with plan: {user.plan}")
-            posthog.capture(form.email.data, 
-                event='user_signed_up', 
+            posthog.capture(
+                'user_signed_up',
+                distinct_id=form.email.data,
                 properties = {
                     'plan': plan,
                     'date_time': formatted_time
@@ -126,8 +127,9 @@ def signup():
             try:
                 months = 1
                 price_dollars = PLAN_PRICES.get(plan, 0)
-                posthog.capture(form.email.data,
-                    event='subscription_purchased',
+                posthog.capture(
+                    'subscription_purchased',
+                    distinct_id=form.email.data,
                     properties={
                         'plan': plan,
                         'months': months,
@@ -177,8 +179,8 @@ def login():
 def logout():
     if current_user.is_authenticated:
         posthog.capture(
-            current_user.email,         # Required - your user's ID
-            event='user_logged_out',    # Required - name of the event       
+            'user_logged_out',                    # Required - name of the event
+            distinct_id=current_user.email,       # Required - your user's ID
             properties={
                 'date_time': formatted_time
             }
@@ -193,7 +195,7 @@ def logout():
 @csrf.exempt  # Disable CSRF for this route for debugging. 
 def search():
     query = request.form.get('query')
-    posthog.capture('search', 'search_performed', {'query': query})
+    posthog.capture('search_performed', distinct_id='search', properties={'query': query})
     return redirect(url_for('search_results', query=query))
 
 @app.route('/search_results')
@@ -388,21 +390,24 @@ def chat_api():
         session['history'].append({"role": "user", "content": user_message})
         session['history'].append({"role": "assistant", "content": ai_text})
 
-        # Capture a basic generation event for visibility even without wrapper
-        try:
-            posthog.capture(
-                distinct_id,
-                event='$ai_generation',
-                properties={
-                    '$ai_model': 'gpt-4o-mini',
-                    '$ai_provider': 'openai',
-                    '$ai_input': user_message,
-                    '$ai_output': ai_text,
-                    '$ai_trace_id': conversation_id,
-                }
-            )
-        except Exception:
-            pass
+        # Capture a basic generation event for visibility even without wrapper.
+        # The LangChain callback and the PostHog-instrumented OpenAI client each
+        # emit $ai_generation themselves, so only capture here when neither is active.
+        if not (langchain_available or openai_instrumented):
+            try:
+                posthog.capture(
+                    '$ai_generation',
+                    distinct_id=distinct_id,
+                    properties={
+                        '$ai_model': 'gpt-4o-mini',
+                        '$ai_provider': 'openai',
+                        '$ai_input': user_message,
+                        '$ai_output': ai_text,
+                        '$ai_trace_id': conversation_id,
+                    }
+                )
+            except Exception:
+                pass
 
         return jsonify({ 'message': ai_text })
     except Exception as e:


### PR DESCRIPTION
I was standing up the demo locally to explore PostHog and hit 500s on signup and search almost immediately, so I dug into why. Sharing the root cause in case it's useful.

## What happens

`pyproject.toml` declares `"posthog>=3.5.0"`, so `uv sync` — and therefore every Makefile target — installs posthog **7.5.1**. In v7 `capture()` takes the event name as its only positional argument:

```python
capture(event: str, **kwargs)   # distinct_id, properties, timestamp, ... are keyword-only
```

All five call sites in `app.py` still use the v3 positional form, which raises:

```
TypeError: Client.capture() got multiple values for argument 'event'       # signup, logout
TypeError: Client.capture() takes 2 positional arguments but 4 were given  # search
```

Result on a clean `make install && make db && make run`:

- `POST /signup` → **500**. The user row is committed at `app.py:116` *before* the failing capture, so the account is created and then the request errors. No `user_signed_up` event.
- `POST /search` → **500**. No `search_performed` event.
- `GET /logout` → **500** for any authenticated user.
- The `$ai_generation` capture in `/chat` fails silently inside `except Exception: pass`.

`requirements.txt` pins `posthog==3.5.0`, so the `pip` path in the README's Prerequisites still works. Only the `uv`/Makefile path — the one the README tells you to use — is affected. This looks like the practical core of #55: that issue reads as a docs nit about `pip` on macOS, but the deeper problem is that the two dependency manifests disagree, and the working one is the one nobody uses.

## What this PR does

Migrates all five `capture()` calls to the v7 signature. `scripts/seed_demo_data.py` already passes everything as kwargs and needed no change.

It also guards the manual `$ai_generation` capture so it only fires when neither the LangChain callback nor the PostHog-instrumented OpenAI client is active. Both already emit `$ai_generation`, so once the call actually worked it double-counted — two events per chat message sharing one `$ai_trace_id`. The existing comment ("even without wrapper") suggests fallback-only was the intent. Happy to split this into its own commit if you'd rather keep the PR to the signature change.

## Verification

Against a scratch PostHog project, same script before and after:

| | before | after |
|---|---|---|
| `POST /signup` | 500 | 302 |
| `POST /search` | 500 | 302 |
| `GET /logout` | 500 | 302 |
| `user_signed_up` events | 0 | 1 |
| `subscription_purchased` events | 0 | 1 |
| `search_performed` events | 0 | 1 |
| `user_logged_out` events | 0 | 1 |
| `$ai_generation` per chat | 1 | 1 |

## Deliberately not touched

Happy to open separate issues/PRs:

- `search_performed` uses the literal string `'search'` as its `distinct_id`, so every search is attributed to one person. Preserved as-is here to keep this a pure signature migration.
- `pyproject.toml:40` has `exclude-newer = "7 days"`, which isn't a valid TOML date — every `uv` command prints a parse warning.
- `subscription_purchased` sits inside a bare `except Exception: pass`, which is what hid this for so long.
