### PR TITLE
Fix posthog.capture() calls broken against posthog-python >= 6 (signup returns 500)

### DIFF
--- a/app.py
+++ b/app.py
@@ -115,8 +115,9 @@ def signup():
             db.session.add(user)
             db.session.commit()
             app.logger.debug(f"New user created: {user.username} with plan: {user.plan}")
-            posthog.capture(form.email.data, 
-                event='user_signed_up', 
+            posthog.capture(
+                event='user_signed_up',
+                distinct_id=form.email.data,
                 properties = {
                     'plan': plan,
                     'date_time': formatted_time
@@ -126,8 +127,9 @@ def signup():
             try:
                 months = 1
                 price_dollars = PLAN_PRICES.get(plan, 0)
-                posthog.capture(form.email.data,
+                posthog.capture(
                     event='subscription_purchased',
+                    distinct_id=form.email.data,
                     properties={
                         'plan': plan,
                         'months': months,
@@ -136,7 +138,9 @@ def signup():
                     }
                 )
             except Exception:
-                pass
+                # Never break signup on a telemetry failure, but don't hide it
+                # either -- this block silently swallowed a broken capture call.
+                app.logger.exception('Failed to capture subscription_purchased event')
             flash('Congratulations, you are now a registered user!')
             return redirect(url_for('login'))
         else:
@@ -177,8 +181,8 @@ def login():
 def logout():
     if current_user.is_authenticated:
         posthog.capture(
-            current_user.email,         # Required - your user's ID
-            event='user_logged_out',    # Required - name of the event       
+            event='user_logged_out',           # Required - name of the event
+            distinct_id=current_user.email,    # Required - your user's ID
             properties={
                 'date_time': formatted_time
             }
@@ -193,7 +197,11 @@ def logout():
 @csrf.exempt  # Disable CSRF for this route for debugging. 
 def search():
     query = request.form.get('query')
-    posthog.capture('search', 'search_performed', {'query': query})
+    posthog.capture(
+        event='search_performed',
+        distinct_id=current_user.email if current_user.is_authenticated else 'anonymous',
+        properties={'query': query}
+    )
     return redirect(url_for('search_results', query=query))
 
 @app.route('/search_results')
@@ -391,8 +399,8 @@ def chat_api():
         # Capture a basic generation event for visibility even without wrapper
         try:
             posthog.capture(
-                distinct_id,
                 event='$ai_generation',
+                distinct_id=distinct_id,
                 properties={
                     '$ai_model': 'gpt-4o-mini',
                     '$ai_provider': 'openai',
@@ -402,7 +410,7 @@ def chat_api():
                 }
             )
         except Exception:
-            pass
+            app.logger.exception('Failed to capture $ai_generation event')
 
         return jsonify({ 'message': ai_text })
     except Exception as e:


### PR DESCRIPTION
# PR: Fix `posthog.capture()` calls for posthog-python v6+ argument signature

**Target:** `PostHog/posthog-demo-3000`
**Branch:** `fix/capture-signature-v7`
**Files:** `app.py` only (5 call sites, 2 log lines)

---

## Title

Fix `posthog.capture()` calls broken against posthog-python >= 6 (signup returns 500)

## Body

### What's wrong

Following the documented setup (`make install`, then `make run`) installs **posthog-python 7.5.1**, and the app's five server-side `posthog.capture()` calls are written against the pre-v6 signature. Signing up returns **HTTP 500**.

In v6+ the signature is:

```python
Client.capture(self, event: str, **kwargs: Unpack[OptionalCaptureArgs]) -> Optional[str]
# OptionalCaptureArgs: distinct_id, properties, timestamp, uuid, groups,
#                      send_feature_flags, disable_geoip
```

`distinct_id` is now keyword-only. The existing calls pass it **positionally**:

```python
posthog.capture(form.email.data, event='user_signed_up', properties={...})
```

Python binds `form.email.data` to `event`, then `event=` collides:

```
TypeError: Client.capture() got multiple values for argument 'event'
```

### Why this is a code bug, not a "pin your deps" bug

`pyproject.toml` declares `posthog>=3.5.0`, so resolving to 7.x is entirely valid under the repo's own constraint. The call sites are incompatible with the dependency range the repo permits.

Worth flagging: `requirements.txt` pins `posthog==3.5.0` while `pyproject.toml` allows `>=3.5.0`. The two manifests disagree, which is why this only reproduces on some paths:

| Setup path | Manifest used | posthog | Result |
|---|---|---|---|
| README Option 1, `pip install -r requirements.txt` | `requirements.txt` | 3.5.0 | works |
| `make install` / `uv sync` / Codespaces | `pyproject.toml` | 7.5.1 | **broken** |

The broken path is the one `make run` and the Codespaces instructions steer people to.

### Why it's worse than a 500

`Client.capture` is wrapped in `@no_throw()`, whose docstring reads: *"Exceptions will still be raised if the debug flag is enabled."* `app.py` sets `posthog.debug = True`, which is the only reason this surfaces loudly.

**With `debug` off, all five calls fail silently** — no events, no errors, an app that looks perfectly healthy. Two of them are additionally wrapped in `except Exception: pass`, so `subscription_purchased` (the Revenue Analytics event) and `$ai_generation` (LLM Analytics) fail silently *today*, even with debug on.

### The fix

All five converted to keyword arguments:

```python
posthog.capture(
    event='user_signed_up',
    distinct_id=form.email.data,
    properties={...}
)
```

Call sites: `user_signed_up`, `subscription_purchased`, `user_logged_out`, `search_performed`, `$ai_generation`.

**Two things bundled in, called out explicitly so you can ask me to split them:**

1. **Search event attribution.** `posthog.capture('search', 'search_performed', {'query': query})` passed three positional args. Beyond the signature, `distinct_id` was the literal string `'search'`, attributing every search in the demo to one fake user. Now uses the current user, falling back to `'anonymous'`.

2. **Bare `except Exception: pass` → `app.logger.exception(...)`.** Telemetry still can't break the request path, but failures are no longer invisible. This pattern is what hid the broken revenue event in the first place.

### Verification

- Before: `POST /signup` → 500, `TypeError: Client.capture() got multiple values for argument 'event'`
- After: `POST /signup` → 302 → `/login`, `user_signed_up` and `subscription_purchased` both land in PostHog
- Verified against posthog-python 7.5.1 on the `make run` path

---

## Related

The two dead feature flags are handled in **PR 2** (`PR-feature-flags.md`), which is independent of this one. Submit this first — it's the higher-severity, less subjective fix.

### Also worth noting (no fix proposed here)

`requirements.txt` (`posthog==3.5.0`) and `pyproject.toml` (`posthog>=3.5.0`) disagree, which is why this reproduces on some setup paths and not others. Happy to align them in a follow-up if you say which direction you want.

---

## Review record

Both findings and the fix were independently reviewed by two other models before writing this up. Both confirmed the diagnosis and that no back-compat shim exists in v7. They split on the bare-except handling (one said fix it in-PR, one said note it only); resolved by fixing it but calling it out separately above so a maintainer can ask for it to be dropped.
