### PR TITLE
Make the two demo feature flags actually fire (one is never created, one is never read)

### DIFF
--- a/scripts/create_posthog_artifacts.py
+++ b/scripts/create_posthog_artifacts.py
@@ -418,6 +418,39 @@ feature_flag_data = {
             }
         }
 
+# templates/index.html reads this flag and branches on the "control" and
+# "james-test" variants to decide whether to show the co-founder signup modal.
+# Without it the modal never appears and the page logs a failed flag evaluation.
+james_experiment_flag_data = {
+            "name": "Shows the co-founder signup modal on the home page.",
+            "key": "james-experiment",
+            "tags": ["demo"],
+            "filters": {
+                "groups": [
+                    {
+                        "variant": None,
+                        "properties": [],
+                        "rollout_percentage": 100
+                    }
+                ],
+                "payloads": {},
+                "multivariate": {
+                    "variants": [
+                        {
+                            "key": "control",
+                            "name": "No modal shown",
+                            "rollout_percentage": 50
+                        },
+                        {
+                            "key": "james-test",
+                            "name": "Show the co-founder signup modal",
+                            "rollout_percentage": 50
+                        }
+                    ]
+                }
+            }
+        }
+
 def make_posthog_api_request(endpoint, data):
     response = requests.post(url + endpoint, headers=headers, json=data)
     if response.status_code == 201:
@@ -493,5 +526,9 @@ feature_flag_data['filters']['groups'][0]['properties'][0]['value'] = cohorts_id
 existing_ff = get_existing_by(feature_flag_endpoint, 'key', feature_flag_data['key'])
 if not existing_ff:
     response = make_posthog_api_request(feature_flag_endpoint, feature_flag_data)
+
+existing_james_ff = get_existing_by(feature_flag_endpoint, 'key', james_experiment_flag_data['key'])
+if not existing_james_ff:
+    response = make_posthog_api_request(feature_flag_endpoint, james_experiment_flag_data)
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -149,3 +149,40 @@
 </script>
 
 {% endblock %}
+
+{% block scripts %}
+<style>
+    /* Hold the catalogue until the flag resolves so the page doesn't render
+       one row and then visibly snap to the other. */
+    body.ph-flags-pending #family-movies,
+    body.ph-flags-pending #action-movies { visibility: hidden; }
+</style>
+<script>
+    // action_mode_on switches the catalogue from family-friendly titles to
+    // action titles. Both rows already exist in the markup; this only decides
+    // which one is shown. Reading the flag through posthog-js also emits
+    // $feature_flag_called, which the flag usage insights report on.
+    document.body.classList.add('ph-flags-pending');
+
+    function applyActionMode(enabled) {
+        document.getElementById('family-movies').style.display = enabled ? 'none' : '';
+        document.getElementById('action-movies').style.display = enabled ? '' : 'none';
+        document.body.classList.remove('ph-flags-pending');
+    }
+
+    if (window.posthog && posthog.onFeatureFlags) {
+        posthog.onFeatureFlags(function () {
+            applyActionMode(posthog.isFeatureEnabled('action_mode_on') === true);
+        });
+        // If flags are slow, blocked, or unavailable, fall back to the default
+        // family view rather than leaving the catalogue hidden.
+        setTimeout(function () {
+            if (document.body.classList.contains('ph-flags-pending')) {
+                applyActionMode(false);
+            }
+        }, 2000);
+    } else {
+        applyActionMode(false);
+    }
+</script>
+{% endblock %}


### PR DESCRIPTION
# PR 2: Make the demo's two feature flags actually work

**Target:** `PostHog/posthog-demo-3000`
**Branch:** `fix/dead-feature-flags`
**Files:** `scripts/create_posthog_artifacts.py`, `templates/index.html`
**Independent of PR 1** — but submit PR 1 first, it fixes a 500.

---

## Title

Fix two feature flags that never fire in the demo

## Body

Both feature flags in this demo are inert out of the box. One is read by the app but never created; the other is created but never read.

Two commits, so either can be dropped independently.

---

### Commit 1 — create the `james-experiment` flag the home page already reads

`templates/index.html` already contains this:

```js
posthog.onFeatureFlags(function() {
    if (posthog.getFeatureFlag('james-experiment') === 'control') { ... }
    else if (posthog.getFeatureFlag('james-experiment') === 'james-test') { showModal(); }
    else { console.log('Feature flag evaluation failed or user is not in any defined variant.'); }
});
```

But `scripts/create_posthog_artifacts.py` only creates `action_mode_on`. Nothing creates `james-experiment`, so a fresh setup always lands in the `else` branch: the co-founder signup modal never appears, and the console logs *"Feature flag evaluation failed or user is not in any defined variant."*

**Fix:** add `james-experiment` to the artifacts script as a multivariate flag with a 50/50 `control` / `james-test` split, following the existing idempotent-by-key pattern.

Variant keys match the template's strings exactly — deliberately not renamed.

**Verified:** deleted the flag, re-ran `make artifacts`, confirmed it recreates with both variants; re-ran again and confirmed it skips rather than duplicating.

---

### Commit 2 — evaluate `action_mode_on` on the home page

The README says the artifacts script creates *"a Feature Flag for the action mode feature **integrated into the app**."* It isn't integrated — the key `action_mode_on` appears nowhere in `app.py` or any template. The only in-app surface is `/feature-flags`, a generic "type a key and check it" tester.

The scaffolding is already there in `index.html`:

```html
<div id="family-movies" class="row">          <!-- visible -->
<div id="action-movies" class="row" style="display: none;">   <!-- never shown -->
```

Both rows render server-side; the second is permanently hidden because nothing evaluates the flag.

**Fix:** read the flag via `posthog.onFeatureFlags` and toggle which row is shown.

Deliberately minimal:
- **Only row visibility changes.** No copy, heading, or layout changes — those are your product decisions, not mine.
- **No flicker.** Both rows are held with `visibility: hidden` until the flag resolves, otherwise the page renders one row and visibly snaps to the other, which is a poor look in a feature-flag demo.
- **Safe fallback.** If flags are slow, blocked, or PostHog is unavailable, it falls back to the default family view after 2s rather than leaving the catalogue hidden. Verified by aborting all requests to `i.posthog.com`.

Reading the flag through posthog-js also emits `$feature_flag_called`, which is what the existing "Feature Flag Called Total Volume" and "Feature Flag calls made by unique users per variant" insights report on — they currently have nothing to show.

**Verified:** flag off → family row shown; flag on → action row shown; PostHog blocked → family row shown, never stuck hidden.

**If commit 2 is unwanted, drop it and keep commit 1.** Commit 1 is pure plumbing for behaviour the template already asks for. Commit 2 completes wiring the README already claims exists, but if you'd rather decide that UX yourselves, I'm happy for it to become an issue instead.

---

## Review record

Scoping was reviewed by three independent models. Two favoured a single PR for both flags; one argued the `action_mode_on` wiring is opinionated enough to warrant its own PR or an issue first. Resolved by keeping one PR with the contentious change isolated in its own commit and explicitly offered for removal.

Two implementation defects they caught were fixed before submission: the flicker on client-side evaluation, and an `h1` text change that was inventing product copy.
