### PR TITLE
docs: Update "Docker Option2" with the right port + DB migration step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 # Copy application files
 COPY . .
 
-# Expose the port Flask listens on
-EXPOSE 8080
+# Expose the port Flask listens on (5000 to match README and local runs)
+EXPOSE 5000
 
-# Command to run the app with Gunicorn
-CMD ["gunicorn", "-b", "0.0.0.0:8080", "app:app"]
+# Command to run the app with Gunicorn on port 5000
+CMD ["gunicorn", "-b", "0.0.0.0:5000", "app:app"]

--- a/README.md
+++ b/README.md
@@ -55,19 +55,25 @@ make run
 
 ### Option 2 - Run as a Container with Docker
 
-The container hasn't been pushed to a registry yet, so you'll need to build and run it yourself. Make sure you have [Docker Desktop for Mac](https://docs.docker.com/desktop/install/mac-install/) installed.
-
-In the root of the repository, first build the container:
+Build and run the container locally (Docker Desktop recommended).
 
 ```bash
+# Build image
 docker build --no-cache --tag posthog-hogflix-demo .
+
+# Run container (map host port -> container 5000). If host 5000 is reserved
+# (AirPlay on macOS), use 5001 or 5002 instead: "-p 5001:5000"
+docker run -d --name hogflix-demo -p 5001:5000 \
+   -e PH_PROJECT_KEY='<Project API key>' \
+   -e PH_HOST='https://<eu or us>.i.posthog.com' \
+   posthog-hogflix-demo
+
+# Initialize the SQLite DB and seed demo data (idempotent)
+docker exec -i hogflix-demo python pop_db.py
 ```
 
-Then run the container in detached mode (background):
-
-```bash
-docker run -d -p 5000:5000 -e PH_PROJECT_KEY=<Project API key> -e PH_HOST='https://<eu or us>.i.posthog.com' posthog-hogflix-demo
-```
+Note: macOS commonly reserves port `5000` for AirPlay — if you see a port bind
+error, pick a different host port (5001, 5002, etc.).
 
 You can then access the app on `localhost:5000`.
 


### PR DESCRIPTION
## Summary
Add explicit DB-init step for Docker Option 2 and note macOS reserving port 5000; update Dockerfile to bind Gunicorn to `5000`.

## Changes
- Updated Dockerfile to bind Gunicorn at `0.0.0.0:5000`.
- README (`Option 2`):
  - Added an explicit DB-init step: `docker exec -i hogflix-demo python pop_db.py`.
  - Added a short note recommending using a non-reserved host port (e.g. `5001`/`5002`) on macOS.

## Why
- Ensures Option 2 works out-of-the-box by creating the SQLite schema and seeding demo data (the app previously raised `sqlite3.OperationalError: no such table: movie` when run in a fresh container).
- Avoids common macOS port conflicts where `5000` may be reserved by AirPlay receiver; recommending an alternative host port reduces friction.

## Validation
- Built image and started container locally.
- Ran `docker exec -i <container> python pop_db.py` to create tables and seed data.
- Verified root endpoint returned `200 OK` after DB initialization.

## How to test locally
```bash
# Build
docker build --no-cache --tag posthog-hogflix-demo .

# Run (use a host port that's not reserved; example: 5001)
docker run -d --name hogflix-demo -p 5001:5000 \
  -e PH_PROJECT_KEY='<Project API key>' \
  -e PH_HOST='https://us.i.posthog.com' \
  posthog-hogflix-demo

# Initialize DB (idempotent)
docker exec -i hogflix-demo python pop_db.py

# Verify
curl -i http://localhost:5001/
docker logs -f hogflix-demo
```