### PR TITLE
fix: install uv in the devcontainer so make run works in Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,13 @@
 {
     "image": "mcr.microsoft.com/devcontainers/python:3.12",
     "postCreateCommand": "bash .devcontainer/postCreate.sh",
-    "forwardPorts": [5000]
+    "forwardPorts": [5000],
+    "customizations": {
+        "vscode": {
+            "extensions": ["ms-python.python"],
+            "settings": {
+                "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"
+            }
+        }
+    }
 }

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -18,8 +18,13 @@ else
   fi
 fi
 
-python -m pip install -U pip || true
-pip install -r requirements.txt || true
+# The Makefile and CI both drive Python through uv, so the container must provide it.
+if ! command -v uv >/dev/null 2>&1; then
+  python -m pip install -U uv
+fi
+
+# uv.lock is the source of truth. uv replaces the stale .venv that the repo still tracks.
+uv sync
 
 echo "postCreate complete. Update .env with your PostHog values, then run: make run"
 


### PR DESCRIPTION
## Problem

`make run` fails in a GitHub Codespace with `uv not found`. An applicant reported it today. The Codespaces path has been broken since 2026-01-18.

PR #60 moved the `Makefile` and the CI workflow to `uv`. It did not update `.devcontainer/`:

1. `devcontainer.json` uses `mcr.microsoft.com/devcontainers/python:3.12` and declares no `features`, so the container provides no `uv`.
2. `postCreate.sh` installed dependencies with `pip install -r requirements.txt`.
3. `make run` expands to `check-env db seed artifacts`, and `db` calls `uv run python pop_db.py`.

CI hides the break. `.github/workflows/tests.yml` installs `uv` with `astral-sh/setup-uv`, so tests pass on every commit while the Codespace stays broken. README Option 3 still tells the reader that Codespaces configures everything automatically.

## Change

1. `postCreate.sh` installs `uv` when the image does not provide it, then runs `uv sync`. The container now reads the same dependency source as the Makefile and CI, which is `uv.lock`.
2. The dependency step drops `|| true`. A silent failure is what let this drift stay hidden.
3. `devcontainer.json` points VS Code at `.venv` and requests the Python extension. Dependencies now live in `.venv` instead of the system Python, so this keeps a direct `python app.py` working in the terminal.

## Verification

1. `bash -n .devcontainer/postCreate.sh` passes.
2. `.devcontainer/devcontainer.json` parses as JSON.
3. `uv sync --dry-run` on a fresh clone of `main` reports `Would replace project environment at: .venv`, so `uv` handles the tracked virtualenv without help.

I did not build the container. Please create a Codespace on this branch, update `.env`, and run `make run`.

## Two related findings, not fixed here

1. The repo tracks two virtualenvs, `.venv/` and `venv/`. Both appear in `.gitignore`, so a commit added them before the ignore rule landed. They make a fresh clone 171 MB. `.venv/bin/python3` points at `/home/codespace/.python/current/bin/python3`, which no longer exists. `uv` prints `Ignoring existing virtual environment linked to non-existent Python interpreter` and replaces the directory, so the container still works. A `git rm -r --cached .venv venv` would help every clone.
2. `pyproject.toml` sets `exclude-newer = "7 days"`, which is a moving cutoff. `uv lock --check` therefore fails every day, and every `uv sync` re-resolves 119 packages and rewrites `uv.lock`. Pin a date if the lockfile should stay stable.
